### PR TITLE
chore: add GitHub Actions CI for backend and frontend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,52 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+
+jobs:
+  ci:
+    name: Build, vet & test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sports_manager_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache-dependency-path: backend/go.sum
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/sports_manager_test?sslmode=disable
+          JWT_SECRET: test-secret-at-least-32-characters-long

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,35 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+
+jobs:
+  ci:
+    name: Lint & build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build (type-check + bundle)
+        run: npm run build


### PR DESCRIPTION
Closes #3

## Summary

- **`backend.yml`** — triggers on PRs to `main` that touch `backend/`. Runs:
  1. `go build ./...`
  2. `go vet ./...`
  3. `go test ./...` (with a Postgres 15 service container)
- **`frontend.yml`** — triggers on PRs to `main` that touch `frontend/`. Runs:
  1. `npm ci`
  2. `npm run lint` (ESLint)
  3. `npm run build` (tsc type-check + Vite bundle)

Both workflows use path filters so only the relevant job runs when only one side changes.

## Test plan

- [ ] Open a PR touching `backend/` → backend CI job appears
- [ ] Open a PR touching `frontend/` → frontend CI job appears
- [ ] Introduce a lint error → frontend CI fails
- [ ] Introduce a type error → frontend CI fails on build step
- [ ] Introduce a Go compilation error → backend CI fails on build step
- [ ] Branch protection blocks merge when checks fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)