### PR TITLE
feat: games feature — log games and track per-player stats

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -109,6 +109,8 @@ func main() {
 		r.Get("/{teamID}/members", teamHandler.ListMembers)
 		r.Post("/{teamID}/members", inviteHandler.CreateInvite)
 		r.Delete("/{teamID}/members/{userID}", teamHandler.RemoveMember)
+		r.Post("/{teamID}/roster", teamHandler.AddRosterMember)
+		r.Put("/{teamID}/members/{memberID}", teamHandler.UpdateMember)
 		r.Get("/{teamID}/playbooks", playbookHandler.ListPlaybooks)
 		r.Post("/{teamID}/playbooks", playbookHandler.CreatePlaybook)
 		r.Get("/{teamID}/games", gameHandler.ListGames)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -139,8 +139,8 @@ func main() {
 		r.Get("/{gameID}", gameHandler.GetGameDetail)
 		r.Put("/{gameID}", gameHandler.UpdateGame)
 		r.Delete("/{gameID}", gameHandler.DeleteGame)
-		r.Put("/{gameID}/stats/{userID}", gameHandler.UpsertStats)
-		r.Patch("/{gameID}/players/{userID}", gameHandler.ToggleDNP)
+		r.Put("/{gameID}/stats/{memberID}", gameHandler.UpsertStats)
+		r.Patch("/{gameID}/players/{memberID}", gameHandler.ToggleDNP)
 	})
 
 	// Play routes

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -60,6 +60,10 @@ func main() {
 	playbookUC := usecase.NewPlaybookUsecase(playbookRepo, teamRepo)
 	playbookHandler := handlers.NewPlaybookHandler(playbookUC)
 
+	gameRepo := repository.NewGameRepository(db)
+	gameUC := usecase.NewGameUsecase(gameRepo, teamRepo)
+	gameHandler := handlers.NewGameHandler(gameUC)
+
 	r := chi.NewRouter()
 
 	// Global middleware
@@ -67,7 +71,7 @@ func main() {
 	r.Use(chimiddleware.Recoverer)
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{optionalEnv("ALLOWED_ORIGIN", "http://localhost:5173")},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Content-Type"},
 		AllowCredentials: true,
 	}))
@@ -107,6 +111,8 @@ func main() {
 		r.Delete("/{teamID}/members/{userID}", teamHandler.RemoveMember)
 		r.Get("/{teamID}/playbooks", playbookHandler.ListPlaybooks)
 		r.Post("/{teamID}/playbooks", playbookHandler.CreatePlaybook)
+		r.Get("/{teamID}/games", gameHandler.ListGames)
+		r.Post("/{teamID}/games", gameHandler.CreateGame)
 	})
 
 	// Invite routes
@@ -123,6 +129,16 @@ func main() {
 		r.Delete("/{playbookID}", playbookHandler.DeletePlaybook)
 		r.Get("/{playbookID}/plays", playbookHandler.ListPlays)
 		r.Post("/{playbookID}/plays", playbookHandler.CreatePlay)
+	})
+
+	// Game routes
+	r.Route("/api/games", func(r chi.Router) {
+		r.Use(middleware.Authenticate(jwtSecret, authUC))
+		r.Get("/{gameID}", gameHandler.GetGameDetail)
+		r.Put("/{gameID}", gameHandler.UpdateGame)
+		r.Delete("/{gameID}", gameHandler.DeleteGame)
+		r.Put("/{gameID}/stats/{userID}", gameHandler.UpsertStats)
+		r.Patch("/{gameID}/players/{userID}", gameHandler.ToggleDNP)
 	})
 
 	// Play routes

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -108,7 +108,7 @@ func main() {
 		r.Delete("/{teamID}", teamHandler.DeleteTeam)
 		r.Get("/{teamID}/members", teamHandler.ListMembers)
 		r.Post("/{teamID}/members", inviteHandler.CreateInvite)
-		r.Delete("/{teamID}/members/{userID}", teamHandler.RemoveMember)
+		r.Delete("/{teamID}/members/{memberID}", teamHandler.RemoveMember)
 		r.Post("/{teamID}/roster", teamHandler.AddRosterMember)
 		r.Put("/{teamID}/members/{memberID}", teamHandler.UpdateMember)
 		r.Get("/{teamID}/playbooks", playbookHandler.ListPlaybooks)

--- a/backend/internal/domains/game.go
+++ b/backend/internal/domains/game.go
@@ -1,0 +1,160 @@
+package domains
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/omnia-core/sports-manager/backend/internal/models"
+)
+
+// ----------------------------------------------------------------------------
+// Usecase interface
+// ----------------------------------------------------------------------------
+
+type GameUsecase interface {
+	CreateGame(ctx context.Context, req CreateGameRequest) (CreateGameResponse, error)
+	ListGames(ctx context.Context, req ListGamesRequest) (ListGamesResponse, error)
+	GetGameDetail(ctx context.Context, req GetGameDetailRequest) (GetGameDetailResponse, error)
+	UpdateGame(ctx context.Context, req UpdateGameRequest) (UpdateGameResponse, error)
+	DeleteGame(ctx context.Context, req DeleteGameRequest) (DeleteGameResponse, error)
+	UpsertStats(ctx context.Context, req UpsertStatsRequest) (UpsertStatsResponse, error)
+	ToggleDNP(ctx context.Context, req ToggleDNPRequest) (ToggleDNPResponse, error)
+}
+
+// ----------------------------------------------------------------------------
+// Repository interface
+// ----------------------------------------------------------------------------
+
+type GameRepository interface {
+	CreateGame(ctx context.Context, req CreateGameRequest) (CreateGameResponse, error)
+	SeedGamePlayers(ctx context.Context, req SeedGamePlayersRequest) (SeedGamePlayersResponse, error)
+	GetGame(ctx context.Context, req GetGameRequest) (GetGameResponse, error)
+	ListGames(ctx context.Context, req ListGamesRequest) (ListGamesResponse, error)
+	GetGameDetail(ctx context.Context, req GetGameDetailRequest) (GetGameDetailResponse, error)
+	UpdateGame(ctx context.Context, req UpdateGameRequest) (UpdateGameResponse, error)
+	DeleteGame(ctx context.Context, req DeleteGameRequest) (DeleteGameResponse, error)
+	UpsertStats(ctx context.Context, req UpsertStatsRequest) (UpsertStatsResponse, error)
+	ToggleDNP(ctx context.Context, req ToggleDNPRequest) (ToggleDNPResponse, error)
+}
+
+// ----------------------------------------------------------------------------
+// Shared composite type
+// ----------------------------------------------------------------------------
+
+// GameDetailPlayer is the combined view of a player's participation in a game,
+// used in the GET /api/games/:gameID response.
+type GameDetailPlayer struct {
+	UserID       uuid.UUID         `json:"user_id"`
+	Name         string            `json:"name"`
+	JerseyNumber *int              `json:"jersey_number"`
+	Position     *string           `json:"position"`
+	IsDNP        bool              `json:"is_dnp"`
+	Stats        *models.GameStats `json:"stats"`
+}
+
+// ----------------------------------------------------------------------------
+// Request / Response types
+// ----------------------------------------------------------------------------
+
+type CreateGameRequest struct {
+	TeamID       uuid.UUID
+	CallerID     uuid.UUID
+	OpponentName string
+	GameDate     time.Time
+}
+
+type CreateGameResponse struct {
+	Game *models.Game
+}
+
+type SeedGamePlayersRequest struct {
+	GameID  uuid.UUID
+	UserIDs []uuid.UUID
+}
+
+type SeedGamePlayersResponse struct{}
+
+type GetGameRequest struct {
+	GameID   uuid.UUID
+	CallerID uuid.UUID
+}
+
+type GetGameResponse struct {
+	Game *models.Game
+}
+
+type ListGamesRequest struct {
+	TeamID   uuid.UUID
+	CallerID uuid.UUID
+}
+
+type ListGamesResponse struct {
+	Games []*models.Game
+}
+
+type GetGameDetailRequest struct {
+	GameID   uuid.UUID
+	CallerID uuid.UUID
+}
+
+type GetGameDetailResponse struct {
+	Game    *models.Game       `json:"game"`
+	Players []GameDetailPlayer `json:"players"`
+}
+
+type UpdateGameRequest struct {
+	GameID        uuid.UUID
+	CallerID      uuid.UUID
+	OpponentName  *string
+	GameDate      *time.Time
+	TeamScore     *int
+	OpponentScore *int
+}
+
+type UpdateGameResponse struct {
+	Game *models.Game
+}
+
+type DeleteGameRequest struct {
+	GameID   uuid.UUID
+	CallerID uuid.UUID
+}
+
+type DeleteGameResponse struct{}
+
+type UpsertStatsRequest struct {
+	GameID    uuid.UUID
+	UserID    uuid.UUID
+	CallerID  uuid.UUID
+	Mins      int
+	Pts       int
+	FGM       int
+	FGA       int
+	ThreePM   int
+	ThreePA   int
+	FTM       int
+	FTA       int
+	ORB       int
+	DRB       int
+	AST       int
+	STL       int
+	BLK       int
+	TOV       int
+	PF        int
+	PlusMinus int
+}
+
+type UpsertStatsResponse struct {
+	Stats *models.GameStats
+}
+
+type ToggleDNPRequest struct {
+	GameID   uuid.UUID
+	UserID   uuid.UUID
+	CallerID uuid.UUID
+}
+
+type ToggleDNPResponse struct {
+	IsDNP bool `json:"is_dnp"`
+}

--- a/backend/internal/domains/game.go
+++ b/backend/internal/domains/game.go
@@ -45,7 +45,7 @@ type GameRepository interface {
 // GameDetailPlayer is the combined view of a player's participation in a game,
 // used in the GET /api/games/:gameID response.
 type GameDetailPlayer struct {
-	UserID       uuid.UUID         `json:"user_id"`
+	MemberID     uuid.UUID         `json:"member_id"`
 	Name         string            `json:"name"`
 	JerseyNumber *int              `json:"jersey_number"`
 	Position     *string           `json:"position"`
@@ -69,8 +69,8 @@ type CreateGameResponse struct {
 }
 
 type SeedGamePlayersRequest struct {
-	GameID  uuid.UUID
-	UserIDs []uuid.UUID
+	GameID    uuid.UUID
+	MemberIDs []uuid.UUID
 }
 
 type SeedGamePlayersResponse struct{}
@@ -125,7 +125,7 @@ type DeleteGameResponse struct{}
 
 type UpsertStatsRequest struct {
 	GameID    uuid.UUID
-	UserID    uuid.UUID
+	MemberID  uuid.UUID
 	CallerID  uuid.UUID
 	Mins      int
 	Pts       int
@@ -151,7 +151,7 @@ type UpsertStatsResponse struct {
 
 type ToggleDNPRequest struct {
 	GameID   uuid.UUID
-	UserID   uuid.UUID
+	MemberID uuid.UUID
 	CallerID uuid.UUID
 }
 

--- a/backend/internal/domains/invite.go
+++ b/backend/internal/domains/invite.go
@@ -43,10 +43,11 @@ type InviteRepository interface {
 // ----------------------------------------------------------------------------
 
 type CreateInviteRequest struct {
-	TeamID   uuid.UUID
-	CallerID uuid.UUID // must be coach on the team
-	Email    string
-	TeamName string // resolved by the usecase; passed to mailer
+	TeamID       uuid.UUID
+	CallerID     uuid.UUID  // must be coach on the team
+	Email        string
+	TeamName     string     // resolved by the usecase; passed to mailer
+	TeamMemberID *uuid.UUID // optional: link invite to a placeholder roster slot
 }
 
 type CreateInviteResponse struct {
@@ -80,12 +81,14 @@ type GetInviteByTeamAndEmailResponse struct {
 }
 
 // AcceptInviteAtomicRequest carries everything the repository needs to execute
-// the accept-invite transaction: mark invite accepted + insert team_members row.
+// the accept-invite transaction: mark invite accepted + upsert team_members row.
+// When TeamMemberID is set the placeholder slot is updated; otherwise a new row is inserted.
 type AcceptInviteAtomicRequest struct {
-	InviteID  uuid.UUID
-	TeamID    uuid.UUID
-	UserID    uuid.UUID
-	ExpiresAt time.Time // used to double-check expiry inside the tx
+	InviteID     uuid.UUID
+	TeamID       uuid.UUID
+	UserID       uuid.UUID
+	TeamMemberID *uuid.UUID // if set, update the placeholder; otherwise insert new row
+	ExpiresAt    time.Time  // used to double-check expiry inside the tx
 }
 
 type AcceptInviteAtomicResponse struct {

--- a/backend/internal/domains/team.go
+++ b/backend/internal/domains/team.go
@@ -133,7 +133,7 @@ type ListMembersResponse struct {
 
 type RemoveMemberRequest struct {
 	TeamID   uuid.UUID
-	UserID   uuid.UUID
+	MemberID uuid.UUID
 	CallerID uuid.UUID
 }
 

--- a/backend/internal/domains/team.go
+++ b/backend/internal/domains/team.go
@@ -20,6 +20,8 @@ type TeamUsecase interface {
 	DeleteTeam(ctx context.Context, req DeleteTeamRequest) (DeleteTeamResponse, error)
 	ListMembers(ctx context.Context, req ListMembersRequest) (ListMembersResponse, error)
 	RemoveMember(ctx context.Context, req RemoveMemberRequest) (RemoveMemberResponse, error)
+	AddRosterMember(ctx context.Context, req AddRosterMemberRequest) (AddRosterMemberResponse, error)
+	UpdateMember(ctx context.Context, req UpdateMemberRequest) (UpdateMemberResponse, error)
 }
 
 // ----------------------------------------------------------------------------
@@ -36,6 +38,8 @@ type TeamRepository interface {
 	GetMembership(ctx context.Context, req GetMembershipRequest) (GetMembershipResponse, error)
 	ListMembers(ctx context.Context, req ListMembersRequest) (ListMembersResponse, error)
 	RemoveMember(ctx context.Context, req RemoveMemberRequest) (RemoveMemberResponse, error)
+	AddRosterMember(ctx context.Context, req AddRosterMemberRequest) (AddRosterMemberResponse, error)
+	UpdateMember(ctx context.Context, req UpdateMemberRequest) (UpdateMemberResponse, error)
 }
 
 // ----------------------------------------------------------------------------
@@ -44,9 +48,10 @@ type TeamRepository interface {
 
 // MemberWithUser pairs a TeamMember record with its associated User so the
 // frontend can render a roster without issuing extra requests.
+// User is nil for placeholder roster slots with no linked account.
 type MemberWithUser struct {
 	Member models.TeamMember `json:"member"`
-	User   models.User       `json:"user"`
+	User   *models.User      `json:"user"`
 }
 
 // ----------------------------------------------------------------------------
@@ -133,3 +138,30 @@ type RemoveMemberRequest struct {
 }
 
 type RemoveMemberResponse struct{}
+
+// AddRosterMemberRequest adds a placeholder roster slot (no user account required).
+type AddRosterMemberRequest struct {
+	TeamID       uuid.UUID
+	CallerID     uuid.UUID
+	Name         string
+	JerseyNumber *int
+	Position     *string
+}
+
+type AddRosterMemberResponse struct {
+	Member *models.TeamMember
+}
+
+// UpdateMemberRequest updates jersey number and/or position for a roster slot.
+type UpdateMemberRequest struct {
+	TeamID       uuid.UUID
+	MemberID     uuid.UUID
+	CallerID     uuid.UUID
+	JerseyNumber *int
+	Position     *string
+	Name         *string
+}
+
+type UpdateMemberResponse struct {
+	Member *models.TeamMember
+}

--- a/backend/internal/handlers/game_handler.go
+++ b/backend/internal/handlers/game_handler.go
@@ -1,0 +1,245 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/omnia-core/sports-manager/backend/internal/domains"
+	"github.com/omnia-core/sports-manager/backend/internal/middleware"
+)
+
+type GameHandler struct {
+	usecase domains.GameUsecase
+}
+
+func NewGameHandler(uc domains.GameUsecase) *GameHandler {
+	return &GameHandler{usecase: uc}
+}
+
+// ListGames handles GET /api/teams/:teamID/games.
+func (h *GameHandler) ListGames(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	teamID, err := parseUUIDParam(r, "teamID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid team ID"))
+		return
+	}
+	res, err := h.usecase.ListGames(r.Context(), domains.ListGamesRequest{TeamID: teamID, CallerID: caller.ID})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"games": res.Games})
+}
+
+type createGameBody struct {
+	OpponentName string `json:"opponent_name"`
+	GameDate     string `json:"game_date"` // "YYYY-MM-DD"
+}
+
+// CreateGame handles POST /api/teams/:teamID/games.
+func (h *GameHandler) CreateGame(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	teamID, err := parseUUIDParam(r, "teamID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid team ID"))
+		return
+	}
+	var body createGameBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+		return
+	}
+	gameDate, err := time.Parse("2006-01-02", body.GameDate)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("game_date must be YYYY-MM-DD"))
+		return
+	}
+	res, err := h.usecase.CreateGame(r.Context(), domains.CreateGameRequest{
+		TeamID:       teamID,
+		CallerID:     caller.ID,
+		OpponentName: body.OpponentName,
+		GameDate:     gameDate,
+	})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, res.Game)
+}
+
+// GetGameDetail handles GET /api/games/:gameID.
+func (h *GameHandler) GetGameDetail(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	gameID, err := parseUUIDParam(r, "gameID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
+		return
+	}
+	res, err := h.usecase.GetGameDetail(r.Context(), domains.GetGameDetailRequest{GameID: gameID, CallerID: caller.ID})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+type updateGameBody struct {
+	OpponentName  *string `json:"opponent_name"`
+	GameDate      *string `json:"game_date"`
+	TeamScore     *int    `json:"team_score"`
+	OpponentScore *int    `json:"opponent_score"`
+}
+
+// UpdateGame handles PUT /api/games/:gameID.
+func (h *GameHandler) UpdateGame(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	gameID, err := parseUUIDParam(r, "gameID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
+		return
+	}
+	var body updateGameBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+		return
+	}
+	req := domains.UpdateGameRequest{
+		GameID:        gameID,
+		CallerID:      caller.ID,
+		OpponentName:  body.OpponentName,
+		TeamScore:     body.TeamScore,
+		OpponentScore: body.OpponentScore,
+	}
+	if body.GameDate != nil {
+		d, err := time.Parse("2006-01-02", *body.GameDate)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("game_date must be YYYY-MM-DD"))
+			return
+		}
+		req.GameDate = &d
+	}
+	res, err := h.usecase.UpdateGame(r.Context(), req)
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res.Game)
+}
+
+// DeleteGame handles DELETE /api/games/:gameID.
+func (h *GameHandler) DeleteGame(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	gameID, err := parseUUIDParam(r, "gameID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
+		return
+	}
+	if _, err := h.usecase.DeleteGame(r.Context(), domains.DeleteGameRequest{GameID: gameID, CallerID: caller.ID}); err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type upsertStatsBody struct {
+	Mins      int `json:"mins"`
+	Pts       int `json:"pts"`
+	FGM       int `json:"fgm"`
+	FGA       int `json:"fga"`
+	ThreePM   int `json:"three_pm"`
+	ThreePA   int `json:"three_pa"`
+	FTM       int `json:"ftm"`
+	FTA       int `json:"fta"`
+	ORB       int `json:"orb"`
+	DRB       int `json:"drb"`
+	AST       int `json:"ast"`
+	STL       int `json:"stl"`
+	BLK       int `json:"blk"`
+	TOV       int `json:"tov"`
+	PF        int `json:"pf"`
+	PlusMinus int `json:"plus_minus"`
+}
+
+// UpsertStats handles PUT /api/games/:gameID/stats/:userID.
+func (h *GameHandler) UpsertStats(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	gameID, err := parseUUIDParam(r, "gameID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
+		return
+	}
+	userID, err := parseUUIDParam(r, "userID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user ID"))
+		return
+	}
+	var body upsertStatsBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+		return
+	}
+	res, err := h.usecase.UpsertStats(r.Context(), domains.UpsertStatsRequest{
+		GameID: gameID, UserID: userID, CallerID: caller.ID,
+		Mins: body.Mins, Pts: body.Pts, FGM: body.FGM, FGA: body.FGA,
+		ThreePM: body.ThreePM, ThreePA: body.ThreePA,
+		FTM: body.FTM, FTA: body.FTA, ORB: body.ORB, DRB: body.DRB,
+		AST: body.AST, STL: body.STL, BLK: body.BLK, TOV: body.TOV,
+		PF: body.PF, PlusMinus: body.PlusMinus,
+	})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res.Stats)
+}
+
+// ToggleDNP handles PATCH /api/games/:gameID/players/:userID.
+func (h *GameHandler) ToggleDNP(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+	gameID, err := parseUUIDParam(r, "gameID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
+		return
+	}
+	userID, err := parseUUIDParam(r, "userID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user ID"))
+		return
+	}
+	res, err := h.usecase.ToggleDNP(r.Context(), domains.ToggleDNPRequest{GameID: gameID, UserID: userID, CallerID: caller.ID})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/backend/internal/handlers/game_handler.go
+++ b/backend/internal/handlers/game_handler.go
@@ -194,9 +194,9 @@ func (h *GameHandler) UpsertStats(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
 		return
 	}
-	userID, err := parseUUIDParam(r, "userID")
+	memberID, err := parseUUIDParam(r, "memberID")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errBody("invalid user ID"))
+		writeJSON(w, http.StatusBadRequest, errBody("invalid member ID"))
 		return
 	}
 	var body upsertStatsBody
@@ -205,7 +205,7 @@ func (h *GameHandler) UpsertStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	res, err := h.usecase.UpsertStats(r.Context(), domains.UpsertStatsRequest{
-		GameID: gameID, UserID: userID, CallerID: caller.ID,
+		GameID: gameID, MemberID: memberID, CallerID: caller.ID,
 		Mins: body.Mins, Pts: body.Pts, FGM: body.FGM, FGA: body.FGA,
 		ThreePM: body.ThreePM, ThreePA: body.ThreePA,
 		FTM: body.FTM, FTA: body.FTA, ORB: body.ORB, DRB: body.DRB,
@@ -231,12 +231,12 @@ func (h *GameHandler) ToggleDNP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errBody("invalid game ID"))
 		return
 	}
-	userID, err := parseUUIDParam(r, "userID")
+	memberID, err := parseUUIDParam(r, "memberID")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errBody("invalid user ID"))
+		writeJSON(w, http.StatusBadRequest, errBody("invalid member ID"))
 		return
 	}
-	res, err := h.usecase.ToggleDNP(r.Context(), domains.ToggleDNPRequest{GameID: gameID, UserID: userID, CallerID: caller.ID})
+	res, err := h.usecase.ToggleDNP(r.Context(), domains.ToggleDNPRequest{GameID: gameID, MemberID: memberID, CallerID: caller.ID})
 	if err != nil {
 		writeUsecaseError(w, err)
 		return

--- a/backend/internal/handlers/invite_handler.go
+++ b/backend/internal/handlers/invite_handler.go
@@ -23,7 +23,8 @@ func NewInviteHandler(uc domains.InviteUsecase) *InviteHandler {
 // --- CreateInvite ------------------------------------------------------
 
 type createInviteRequest struct {
-	Email string `json:"email"`
+	Email        string     `json:"email"`
+	MemberID     *uuid.UUID `json:"member_id"` // optional: link to a placeholder roster slot
 }
 
 // CreateInvite handles POST /api/teams/:teamID/members.
@@ -48,9 +49,10 @@ func (h *InviteHandler) CreateInvite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := h.usecase.CreateInvite(r.Context(), domains.CreateInviteRequest{
-		TeamID:   teamID,
-		CallerID: caller.ID,
-		Email:    body.Email,
+		TeamID:       teamID,
+		CallerID:     caller.ID,
+		Email:        body.Email,
+		TeamMemberID: body.MemberID,
 	})
 	if err != nil {
 		writeUsecaseError(w, err)

--- a/backend/internal/handlers/team_handler.go
+++ b/backend/internal/handlers/team_handler.go
@@ -244,6 +244,100 @@ func (h *TeamHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// --- AddRosterMember ---------------------------------------------------
+
+type addRosterMemberRequest struct {
+	Name         string `json:"name"`
+	JerseyNumber *int   `json:"jersey_number"`
+	Position     *string `json:"position"`
+}
+
+// AddRosterMember handles POST /api/teams/:teamID/roster.
+// Adds a named placeholder slot without requiring an existing user account.
+func (h *TeamHandler) AddRosterMember(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+
+	teamID, err := parseUUIDParam(r, "teamID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid team ID"))
+		return
+	}
+
+	var body addRosterMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+		return
+	}
+
+	res, err := h.usecase.AddRosterMember(r.Context(), domains.AddRosterMemberRequest{
+		TeamID:       teamID,
+		CallerID:     caller.ID,
+		Name:         body.Name,
+		JerseyNumber: body.JerseyNumber,
+		Position:     body.Position,
+	})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, res.Member)
+}
+
+// --- UpdateMember ------------------------------------------------------
+
+type updateMemberRequest struct {
+	JerseyNumber *int    `json:"jersey_number"`
+	Position     *string `json:"position"`
+	Name         *string `json:"name"`
+}
+
+// UpdateMember handles PUT /api/teams/:teamID/members/:memberID.
+func (h *TeamHandler) UpdateMember(w http.ResponseWriter, r *http.Request) {
+	caller, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("not authenticated"))
+		return
+	}
+
+	teamID, err := parseUUIDParam(r, "teamID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid team ID"))
+		return
+	}
+
+	memberID, err := parseUUIDParam(r, "memberID")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid member ID"))
+		return
+	}
+
+	var body updateMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+		return
+	}
+
+	res, err := h.usecase.UpdateMember(r.Context(), domains.UpdateMemberRequest{
+		TeamID:       teamID,
+		MemberID:     memberID,
+		CallerID:     caller.ID,
+		JerseyNumber: body.JerseyNumber,
+		Position:     body.Position,
+		Name:         body.Name,
+	})
+	if err != nil {
+		writeUsecaseError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, res.Member)
+}
+
 // --- helpers -----------------------------------------------------------
 
 // parseUUIDParam extracts and parses a named chi URL parameter as a UUID.

--- a/backend/internal/handlers/team_handler.go
+++ b/backend/internal/handlers/team_handler.go
@@ -225,15 +225,15 @@ func (h *TeamHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, err := parseUUIDParam(r, "userID")
+	memberID, err := parseUUIDParam(r, "memberID")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errBody("invalid user ID"))
+		writeJSON(w, http.StatusBadRequest, errBody("invalid member ID"))
 		return
 	}
 
 	_, err = h.usecase.RemoveMember(r.Context(), domains.RemoveMemberRequest{
 		TeamID:   teamID,
-		UserID:   userID,
+		MemberID: memberID,
 		CallerID: caller.ID,
 	})
 	if err != nil {

--- a/backend/internal/models/game.go
+++ b/backend/internal/models/game.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Game represents a single game record for a team.
+type Game struct {
+	ID            uuid.UUID `json:"id"`
+	TeamID        uuid.UUID `json:"team_id"`
+	OpponentName  string    `json:"opponent_name"`
+	GameDate      time.Time `json:"game_date"`
+	TeamScore     *int      `json:"team_score"`
+	OpponentScore *int      `json:"opponent_score"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// GamePlayer is a team member's entry for a specific game.
+// is_dnp=true means they did not play.
+type GamePlayer struct {
+	ID        uuid.UUID `json:"id"`
+	GameID    uuid.UUID `json:"game_id"`
+	UserID    uuid.UUID `json:"user_id"`
+	IsDNP     bool      `json:"is_dnp"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// GameStats holds per-player counting stats for a game.
+// FG%, 3P%, FT%, and REB are computed on the frontend.
+type GameStats struct {
+	ID           uuid.UUID `json:"id"`
+	GamePlayerID uuid.UUID `json:"game_player_id"`
+	Mins         int       `json:"mins"`
+	Pts          int       `json:"pts"`
+	FGM          int       `json:"fgm"`
+	FGA          int       `json:"fga"`
+	ThreePM      int       `json:"three_pm"`
+	ThreePA      int       `json:"three_pa"`
+	FTM          int       `json:"ftm"`
+	FTA          int       `json:"fta"`
+	ORB          int       `json:"orb"`
+	DRB          int       `json:"drb"`
+	AST          int       `json:"ast"`
+	STL          int       `json:"stl"`
+	BLK          int       `json:"blk"`
+	TOV          int       `json:"tov"`
+	PF           int       `json:"pf"`
+	PlusMinus    int       `json:"plus_minus"`
+}

--- a/backend/internal/models/invite.go
+++ b/backend/internal/models/invite.go
@@ -7,12 +7,14 @@ import (
 )
 
 // TeamInvite represents a pending or resolved invitation for a player to join a team.
+// TeamMemberID links the invite to a specific placeholder roster slot when set.
 type TeamInvite struct {
-	ID        uuid.UUID `json:"id"`
-	TeamID    uuid.UUID `json:"team_id"`
-	Email     string    `json:"email"`
-	Token     uuid.UUID `json:"token"`
-	Status    string    `json:"status"`
-	ExpiresAt time.Time `json:"expires_at"`
-	CreatedAt time.Time `json:"created_at"`
+	ID           uuid.UUID  `json:"id"`
+	TeamID       uuid.UUID  `json:"team_id"`
+	Email        string     `json:"email"`
+	Token        uuid.UUID  `json:"token"`
+	Status       string     `json:"status"`
+	TeamMemberID *uuid.UUID `json:"team_member_id"`
+	ExpiresAt    time.Time  `json:"expires_at"`
+	CreatedAt    time.Time  `json:"created_at"`
 }

--- a/backend/internal/models/team.go
+++ b/backend/internal/models/team.go
@@ -17,12 +17,15 @@ type Team struct {
 }
 
 // TeamMember represents a user's membership in a team with a team-scoped role.
+// UserID is nil for placeholder roster slots that have not yet been linked to a user account.
+// Name stores the display name for placeholder members.
 type TeamMember struct {
-	ID           uuid.UUID `json:"id"`
-	TeamID       uuid.UUID `json:"team_id"`
-	UserID       uuid.UUID `json:"user_id"`
-	Role         string    `json:"role"`
-	JerseyNumber *int      `json:"jersey_number"`
-	Position     *string   `json:"position"`
-	JoinedAt     time.Time `json:"joined_at"`
+	ID           uuid.UUID  `json:"id"`
+	TeamID       uuid.UUID  `json:"team_id"`
+	UserID       *uuid.UUID `json:"user_id"`
+	Name         *string    `json:"name"`
+	Role         string     `json:"role"`
+	JerseyNumber *int       `json:"jersey_number"`
+	Position     *string    `json:"position"`
+	JoinedAt     time.Time  `json:"joined_at"`
 }

--- a/backend/internal/repository/game_repository.go
+++ b/backend/internal/repository/game_repository.go
@@ -1,0 +1,250 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/omnia-core/sports-manager/backend/internal/domains"
+	"github.com/omnia-core/sports-manager/backend/internal/models"
+)
+
+type gameRepository struct {
+	db *sql.DB
+}
+
+func NewGameRepository(db *sql.DB) domains.GameRepository {
+	return &gameRepository{db: db}
+}
+
+func (r *gameRepository) CreateGame(ctx context.Context, req domains.CreateGameRequest) (domains.CreateGameResponse, error) {
+	const q = `
+		INSERT INTO games (team_id, opponent_name, game_date)
+		VALUES ($1, $2, $3)
+		RETURNING id, team_id, opponent_name, game_date, team_score, opponent_score, created_at`
+	g := &models.Game{}
+	err := r.db.QueryRowContext(ctx, q, req.TeamID, req.OpponentName, req.GameDate).Scan(
+		&g.ID, &g.TeamID, &g.OpponentName, &g.GameDate, &g.TeamScore, &g.OpponentScore, &g.CreatedAt,
+	)
+	if err != nil {
+		return domains.CreateGameResponse{}, fmt.Errorf("create game: %w", err)
+	}
+	return domains.CreateGameResponse{Game: g}, nil
+}
+
+func (r *gameRepository) SeedGamePlayers(ctx context.Context, req domains.SeedGamePlayersRequest) (domains.SeedGamePlayersResponse, error) {
+	const q = `INSERT INTO game_players (game_id, user_id) VALUES ($1, $2) ON CONFLICT (game_id, user_id) DO NOTHING`
+	for _, uid := range req.UserIDs {
+		if _, err := r.db.ExecContext(ctx, q, req.GameID, uid); err != nil {
+			return domains.SeedGamePlayersResponse{}, fmt.Errorf("seed game player %s: %w", uid, err)
+		}
+	}
+	return domains.SeedGamePlayersResponse{}, nil
+}
+
+func (r *gameRepository) GetGame(ctx context.Context, req domains.GetGameRequest) (domains.GetGameResponse, error) {
+	const q = `
+		SELECT id, team_id, opponent_name, game_date, team_score, opponent_score, created_at
+		FROM games WHERE id = $1`
+	g := &models.Game{}
+	err := r.db.QueryRowContext(ctx, q, req.GameID).Scan(
+		&g.ID, &g.TeamID, &g.OpponentName, &g.GameDate, &g.TeamScore, &g.OpponentScore, &g.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domains.GetGameResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return domains.GetGameResponse{}, fmt.Errorf("get game: %w", err)
+	}
+	return domains.GetGameResponse{Game: g}, nil
+}
+
+func (r *gameRepository) ListGames(ctx context.Context, req domains.ListGamesRequest) (domains.ListGamesResponse, error) {
+	const q = `
+		SELECT id, team_id, opponent_name, game_date, team_score, opponent_score, created_at
+		FROM games WHERE team_id = $1 ORDER BY game_date DESC, created_at DESC`
+	rows, err := r.db.QueryContext(ctx, q, req.TeamID)
+	if err != nil {
+		return domains.ListGamesResponse{}, fmt.Errorf("list games: %w", err)
+	}
+	defer rows.Close()
+
+	var games []*models.Game
+	for rows.Next() {
+		g := &models.Game{}
+		if err := rows.Scan(&g.ID, &g.TeamID, &g.OpponentName, &g.GameDate, &g.TeamScore, &g.OpponentScore, &g.CreatedAt); err != nil {
+			return domains.ListGamesResponse{}, fmt.Errorf("scan game: %w", err)
+		}
+		games = append(games, g)
+	}
+	if err := rows.Err(); err != nil {
+		return domains.ListGamesResponse{}, fmt.Errorf("list games rows: %w", err)
+	}
+	if games == nil {
+		games = []*models.Game{}
+	}
+	return domains.ListGamesResponse{Games: games}, nil
+}
+
+func (r *gameRepository) GetGameDetail(ctx context.Context, req domains.GetGameDetailRequest) (domains.GetGameDetailResponse, error) {
+	// Fetch the game itself
+	gameRes, err := r.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID})
+	if err != nil {
+		return domains.GetGameDetailResponse{}, err
+	}
+
+	// Fetch players + stats via JOIN
+	const q = `
+		SELECT
+			gp.user_id,
+			gp.is_dnp,
+			u.name,
+			tm.jersey_number,
+			tm.position,
+			gs.id,
+			gs.game_player_id,
+			gs.mins, gs.pts, gs.fgm, gs.fga,
+			gs.three_pm, gs.three_pa,
+			gs.ftm, gs.fta,
+			gs.orb, gs.drb,
+			gs.ast, gs.stl, gs.blk, gs.tov, gs.pf, gs.plus_minus
+		FROM game_players gp
+		JOIN users u ON u.id = gp.user_id
+		LEFT JOIN team_members tm ON tm.team_id = $2 AND tm.user_id = gp.user_id
+		LEFT JOIN game_stats gs ON gs.game_player_id = gp.id
+		WHERE gp.game_id = $1
+		ORDER BY gp.created_at ASC`
+
+	rows, err := r.db.QueryContext(ctx, q, req.GameID, gameRes.Game.TeamID)
+	if err != nil {
+		return domains.GetGameDetailResponse{}, fmt.Errorf("get game detail: %w", err)
+	}
+	defer rows.Close()
+
+	var players []domains.GameDetailPlayer
+	for rows.Next() {
+		var p domains.GameDetailPlayer
+		var statsID, statsGamePlayerID *uuid.UUID
+		var mins, pts, fgm, fga, threePM, threePA, ftm, fta, orb, drb, ast, stl, blk, tov, pf, plusMinus *int
+		if err := rows.Scan(
+			&p.UserID, &p.IsDNP, &p.Name, &p.JerseyNumber, &p.Position,
+			&statsID, &statsGamePlayerID,
+			&mins, &pts, &fgm, &fga, &threePM, &threePA,
+			&ftm, &fta, &orb, &drb, &ast, &stl, &blk, &tov, &pf, &plusMinus,
+		); err != nil {
+			return domains.GetGameDetailResponse{}, fmt.Errorf("scan game detail row: %w", err)
+		}
+		if statsID != nil {
+			p.Stats = &models.GameStats{
+				ID: *statsID, GamePlayerID: *statsGamePlayerID,
+				Mins: *mins, Pts: *pts, FGM: *fgm, FGA: *fga,
+				ThreePM: *threePM, ThreePA: *threePA,
+				FTM: *ftm, FTA: *fta, ORB: *orb, DRB: *drb,
+				AST: *ast, STL: *stl, BLK: *blk, TOV: *tov, PF: *pf, PlusMinus: *plusMinus,
+			}
+		}
+		players = append(players, p)
+	}
+	if err := rows.Err(); err != nil {
+		return domains.GetGameDetailResponse{}, fmt.Errorf("game detail rows: %w", err)
+	}
+	if players == nil {
+		players = []domains.GameDetailPlayer{}
+	}
+	return domains.GetGameDetailResponse{Game: gameRes.Game, Players: players}, nil
+}
+
+func (r *gameRepository) UpdateGame(ctx context.Context, req domains.UpdateGameRequest) (domains.UpdateGameResponse, error) {
+	const q = `
+		UPDATE games SET
+			opponent_name  = COALESCE($1, opponent_name),
+			game_date      = COALESCE($2, game_date),
+			team_score     = COALESCE($3, team_score),
+			opponent_score = COALESCE($4, opponent_score)
+		WHERE id = $5
+		RETURNING id, team_id, opponent_name, game_date, team_score, opponent_score, created_at`
+	g := &models.Game{}
+	err := r.db.QueryRowContext(ctx, q,
+		req.OpponentName, req.GameDate, req.TeamScore, req.OpponentScore, req.GameID,
+	).Scan(&g.ID, &g.TeamID, &g.OpponentName, &g.GameDate, &g.TeamScore, &g.OpponentScore, &g.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domains.UpdateGameResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return domains.UpdateGameResponse{}, fmt.Errorf("update game: %w", err)
+	}
+	return domains.UpdateGameResponse{Game: g}, nil
+}
+
+func (r *gameRepository) DeleteGame(ctx context.Context, req domains.DeleteGameRequest) (domains.DeleteGameResponse, error) {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM games WHERE id = $1`, req.GameID)
+	if err != nil {
+		return domains.DeleteGameResponse{}, fmt.Errorf("delete game: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return domains.DeleteGameResponse{}, fmt.Errorf("delete game rows affected: %w", err)
+	}
+	if n == 0 {
+		return domains.DeleteGameResponse{}, ErrNotFound
+	}
+	return domains.DeleteGameResponse{}, nil
+}
+
+func (r *gameRepository) UpsertStats(ctx context.Context, req domains.UpsertStatsRequest) (domains.UpsertStatsResponse, error) {
+	const q = `
+		INSERT INTO game_stats (game_player_id, mins, pts, fgm, fga, three_pm, three_pa, ftm, fta, orb, drb, ast, stl, blk, tov, pf, plus_minus)
+		SELECT gp.id, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+		FROM game_players gp
+		WHERE gp.game_id = $1 AND gp.user_id = $2
+		ON CONFLICT (game_player_id) DO UPDATE SET
+			mins = EXCLUDED.mins, pts = EXCLUDED.pts,
+			fgm = EXCLUDED.fgm, fga = EXCLUDED.fga,
+			three_pm = EXCLUDED.three_pm, three_pa = EXCLUDED.three_pa,
+			ftm = EXCLUDED.ftm, fta = EXCLUDED.fta,
+			orb = EXCLUDED.orb, drb = EXCLUDED.drb,
+			ast = EXCLUDED.ast, stl = EXCLUDED.stl,
+			blk = EXCLUDED.blk, tov = EXCLUDED.tov,
+			pf = EXCLUDED.pf, plus_minus = EXCLUDED.plus_minus
+		RETURNING id, game_player_id, mins, pts, fgm, fga, three_pm, three_pa, ftm, fta, orb, drb, ast, stl, blk, tov, pf, plus_minus`
+
+	s := &models.GameStats{}
+	err := r.db.QueryRowContext(ctx, q,
+		req.GameID, req.UserID,
+		req.Mins, req.Pts, req.FGM, req.FGA,
+		req.ThreePM, req.ThreePA,
+		req.FTM, req.FTA,
+		req.ORB, req.DRB,
+		req.AST, req.STL, req.BLK, req.TOV, req.PF, req.PlusMinus,
+	).Scan(
+		&s.ID, &s.GamePlayerID,
+		&s.Mins, &s.Pts, &s.FGM, &s.FGA,
+		&s.ThreePM, &s.ThreePA,
+		&s.FTM, &s.FTA, &s.ORB, &s.DRB,
+		&s.AST, &s.STL, &s.BLK, &s.TOV, &s.PF, &s.PlusMinus,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domains.UpsertStatsResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return domains.UpsertStatsResponse{}, fmt.Errorf("upsert stats: %w", err)
+	}
+	return domains.UpsertStatsResponse{Stats: s}, nil
+}
+
+func (r *gameRepository) ToggleDNP(ctx context.Context, req domains.ToggleDNPRequest) (domains.ToggleDNPResponse, error) {
+	var isDNP bool
+	err := r.db.QueryRowContext(ctx,
+		`UPDATE game_players SET is_dnp = NOT is_dnp WHERE game_id = $1 AND user_id = $2 RETURNING is_dnp`,
+		req.GameID, req.UserID,
+	).Scan(&isDNP)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domains.ToggleDNPResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return domains.ToggleDNPResponse{}, fmt.Errorf("toggle dnp: %w", err)
+	}
+	return domains.ToggleDNPResponse{IsDNP: isDNP}, nil
+}

--- a/backend/internal/repository/game_repository.go
+++ b/backend/internal/repository/game_repository.go
@@ -35,10 +35,15 @@ func (r *gameRepository) CreateGame(ctx context.Context, req domains.CreateGameR
 }
 
 func (r *gameRepository) SeedGamePlayers(ctx context.Context, req domains.SeedGamePlayersRequest) (domains.SeedGamePlayersResponse, error) {
-	const q = `INSERT INTO game_players (game_id, user_id) VALUES ($1, $2) ON CONFLICT (game_id, user_id) DO NOTHING`
-	for _, uid := range req.UserIDs {
-		if _, err := r.db.ExecContext(ctx, q, req.GameID, uid); err != nil {
-			return domains.SeedGamePlayersResponse{}, fmt.Errorf("seed game player %s: %w", uid, err)
+	const q = `
+		INSERT INTO game_players (game_id, team_member_id, user_id)
+		SELECT $1, tm.id, tm.user_id
+		FROM team_members tm
+		WHERE tm.id = $2
+		ON CONFLICT (game_id, team_member_id) DO NOTHING`
+	for _, mid := range req.MemberIDs {
+		if _, err := r.db.ExecContext(ctx, q, req.GameID, mid); err != nil {
+			return domains.SeedGamePlayersResponse{}, fmt.Errorf("seed game player %s: %w", mid, err)
 		}
 	}
 	return domains.SeedGamePlayersResponse{}, nil
@@ -95,12 +100,13 @@ func (r *gameRepository) GetGameDetail(ctx context.Context, req domains.GetGameD
 		return domains.GetGameDetailResponse{}, err
 	}
 
-	// Fetch players + stats via JOIN
+	// Fetch players + stats via JOIN. Name comes from the user account when available,
+	// otherwise from the team_members placeholder name.
 	const q = `
 		SELECT
-			gp.user_id,
+			gp.team_member_id,
 			gp.is_dnp,
-			u.name,
+			COALESCE(u.name, tm.name, '') AS name,
 			tm.jersey_number,
 			tm.position,
 			gs.id,
@@ -111,13 +117,13 @@ func (r *gameRepository) GetGameDetail(ctx context.Context, req domains.GetGameD
 			gs.orb, gs.drb,
 			gs.ast, gs.stl, gs.blk, gs.tov, gs.pf, gs.plus_minus
 		FROM game_players gp
-		JOIN users u ON u.id = gp.user_id
-		LEFT JOIN team_members tm ON tm.team_id = $2 AND tm.user_id = gp.user_id
+		JOIN team_members tm ON tm.id = gp.team_member_id
+		LEFT JOIN users u ON u.id = tm.user_id
 		LEFT JOIN game_stats gs ON gs.game_player_id = gp.id
 		WHERE gp.game_id = $1
 		ORDER BY gp.created_at ASC`
 
-	rows, err := r.db.QueryContext(ctx, q, req.GameID, gameRes.Game.TeamID)
+	rows, err := r.db.QueryContext(ctx, q, req.GameID)
 	if err != nil {
 		return domains.GetGameDetailResponse{}, fmt.Errorf("get game detail: %w", err)
 	}
@@ -129,7 +135,7 @@ func (r *gameRepository) GetGameDetail(ctx context.Context, req domains.GetGameD
 		var statsID, statsGamePlayerID *uuid.UUID
 		var mins, pts, fgm, fga, threePM, threePA, ftm, fta, orb, drb, ast, stl, blk, tov, pf, plusMinus *int
 		if err := rows.Scan(
-			&p.UserID, &p.IsDNP, &p.Name, &p.JerseyNumber, &p.Position,
+			&p.MemberID, &p.IsDNP, &p.Name, &p.JerseyNumber, &p.Position,
 			&statsID, &statsGamePlayerID,
 			&mins, &pts, &fgm, &fga, &threePM, &threePA,
 			&ftm, &fta, &orb, &drb, &ast, &stl, &blk, &tov, &pf, &plusMinus,
@@ -198,7 +204,7 @@ func (r *gameRepository) UpsertStats(ctx context.Context, req domains.UpsertStat
 		INSERT INTO game_stats (game_player_id, mins, pts, fgm, fga, three_pm, three_pa, ftm, fta, orb, drb, ast, stl, blk, tov, pf, plus_minus)
 		SELECT gp.id, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
 		FROM game_players gp
-		WHERE gp.game_id = $1 AND gp.user_id = $2
+		WHERE gp.game_id = $1 AND gp.team_member_id = $2
 		ON CONFLICT (game_player_id) DO UPDATE SET
 			mins = EXCLUDED.mins, pts = EXCLUDED.pts,
 			fgm = EXCLUDED.fgm, fga = EXCLUDED.fga,
@@ -212,7 +218,7 @@ func (r *gameRepository) UpsertStats(ctx context.Context, req domains.UpsertStat
 
 	s := &models.GameStats{}
 	err := r.db.QueryRowContext(ctx, q,
-		req.GameID, req.UserID,
+		req.GameID, req.MemberID,
 		req.Mins, req.Pts, req.FGM, req.FGA,
 		req.ThreePM, req.ThreePA,
 		req.FTM, req.FTA,
@@ -237,8 +243,8 @@ func (r *gameRepository) UpsertStats(ctx context.Context, req domains.UpsertStat
 func (r *gameRepository) ToggleDNP(ctx context.Context, req domains.ToggleDNPRequest) (domains.ToggleDNPResponse, error) {
 	var isDNP bool
 	err := r.db.QueryRowContext(ctx,
-		`UPDATE game_players SET is_dnp = NOT is_dnp WHERE game_id = $1 AND user_id = $2 RETURNING is_dnp`,
-		req.GameID, req.UserID,
+		`UPDATE game_players SET is_dnp = NOT is_dnp WHERE game_id = $1 AND team_member_id = $2 RETURNING is_dnp`,
+		req.GameID, req.MemberID,
 	).Scan(&isDNP)
 	if errors.Is(err, sql.ErrNoRows) {
 		return domains.ToggleDNPResponse{}, ErrNotFound

--- a/backend/internal/repository/invite_repository.go
+++ b/backend/internal/repository/invite_repository.go
@@ -18,7 +18,7 @@ var ErrAlreadyMember = errors.New("user is already a member of this team")
 //
 // Transaction design note: AcceptInviteAtomic manages its own transaction
 // internally. This keeps *sql.Tx out of the usecase layer and ensures the
-// two writes (insert team_members + update invite status) are always atomic
+// two writes (upsert team_members + update invite status) are always atomic
 // without leaking DB primitives beyond the repository boundary.
 type inviteRepository struct {
 	db *sql.DB
@@ -32,17 +32,18 @@ func NewInviteRepository(db *sql.DB) domains.InviteRepository {
 // CreateInvite inserts a new team_invites row and returns the created record.
 func (r *inviteRepository) CreateInvite(ctx context.Context, req domains.CreateInviteRequest) (domains.CreateInviteResponse, error) {
 	const q = `
-		INSERT INTO team_invites (team_id, email)
-		VALUES ($1, $2)
-		RETURNING id, team_id, email, token, status, expires_at, created_at`
+		INSERT INTO team_invites (team_id, email, team_member_id)
+		VALUES ($1, $2, $3)
+		RETURNING id, team_id, email, token, status, team_member_id, expires_at, created_at`
 
 	inv := &models.TeamInvite{}
-	err := r.db.QueryRowContext(ctx, q, req.TeamID, req.Email).Scan(
+	err := r.db.QueryRowContext(ctx, q, req.TeamID, req.Email, req.TeamMemberID).Scan(
 		&inv.ID,
 		&inv.TeamID,
 		&inv.Email,
 		&inv.Token,
 		&inv.Status,
+		&inv.TeamMemberID,
 		&inv.ExpiresAt,
 		&inv.CreatedAt,
 	)
@@ -55,7 +56,7 @@ func (r *inviteRepository) CreateInvite(ctx context.Context, req domains.CreateI
 // GetInviteByToken returns the invite matching the given token, or ErrNotFound.
 func (r *inviteRepository) GetInviteByToken(ctx context.Context, req domains.GetInviteByTokenRequest) (domains.GetInviteByTokenResponse, error) {
 	const q = `
-		SELECT id, team_id, email, token, status, expires_at, created_at
+		SELECT id, team_id, email, token, status, team_member_id, expires_at, created_at
 		FROM team_invites
 		WHERE token = $1`
 
@@ -66,6 +67,7 @@ func (r *inviteRepository) GetInviteByToken(ctx context.Context, req domains.Get
 		&inv.Email,
 		&inv.Token,
 		&inv.Status,
+		&inv.TeamMemberID,
 		&inv.ExpiresAt,
 		&inv.CreatedAt,
 	)
@@ -82,7 +84,7 @@ func (r *inviteRepository) GetInviteByToken(ctx context.Context, req domains.Get
 // pair, or ErrNotFound. Used to enforce the no-duplicate-pending-invite rule.
 func (r *inviteRepository) GetInviteByTeamAndEmail(ctx context.Context, req domains.GetInviteByTeamAndEmailRequest) (domains.GetInviteByTeamAndEmailResponse, error) {
 	const q = `
-		SELECT id, team_id, email, token, status, expires_at, created_at
+		SELECT id, team_id, email, token, status, team_member_id, expires_at, created_at
 		FROM team_invites
 		WHERE team_id = $1 AND email = $2
 		ORDER BY created_at DESC
@@ -95,6 +97,7 @@ func (r *inviteRepository) GetInviteByTeamAndEmail(ctx context.Context, req doma
 		&inv.Email,
 		&inv.Token,
 		&inv.Status,
+		&inv.TeamMemberID,
 		&inv.ExpiresAt,
 		&inv.CreatedAt,
 	)
@@ -107,16 +110,12 @@ func (r *inviteRepository) GetInviteByTeamAndEmail(ctx context.Context, req doma
 	return domains.GetInviteByTeamAndEmailResponse{Invite: inv}, nil
 }
 
-// AcceptInviteAtomic inserts a team_members row for the accepting user and
-// marks the invite as accepted, all within a single transaction. If either
-// write fails the transaction is rolled back and an error is returned.
+// AcceptInviteAtomic marks the invite accepted and either updates the placeholder
+// roster slot (when TeamMemberID is set) or inserts a new team_members row,
+// all within a single transaction.
 //
-// The UPDATE re-checks expires_at inside the transaction to close the
-// TOCTOU window between the usecase's expiry check and this write. If 0
-// rows are updated, the invite has expired concurrently and ErrInviteInvalid
-// is returned (mapped from the usecase sentinel in the handler).
-//
-// If the user is already a member of the team, ErrAlreadyMember is returned.
+// The UPDATE re-checks expires_at inside the transaction to close the TOCTOU
+// window between the usecase's expiry check and this write.
 func (r *inviteRepository) AcceptInviteAtomic(ctx context.Context, req domains.AcceptInviteAtomicRequest) (domains.AcceptInviteAtomicResponse, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -124,11 +123,40 @@ func (r *inviteRepository) AcceptInviteAtomic(ctx context.Context, req domains.A
 	}
 	defer tx.Rollback() //nolint:errcheck // rolled back on error paths; committed on success
 
-	m, err := insertMember(ctx, tx, domains.AddMemberRequest{
-		TeamID: req.TeamID,
-		UserID: req.UserID,
-		Role:   "player",
-	})
+	var m *models.TeamMember
+	if req.TeamMemberID != nil {
+		// Update the placeholder slot: set user_id to link the account.
+		const updateMemberQ = `
+			UPDATE team_members
+			SET user_id = $1
+			WHERE id = $2 AND team_id = $3 AND user_id IS NULL
+			RETURNING id, team_id, user_id, name, role, jersey_number, position, joined_at`
+		m = &models.TeamMember{}
+		err = tx.QueryRowContext(ctx, updateMemberQ, req.UserID, req.TeamMemberID, req.TeamID).Scan(
+			&m.ID,
+			&m.TeamID,
+			&m.UserID,
+			&m.Name,
+			&m.Role,
+			&m.JerseyNumber,
+			&m.Position,
+			&m.JoinedAt,
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			// Slot was already claimed or doesn't exist — fall back to inserting a new row.
+			m, err = insertMember(ctx, tx, domains.AddMemberRequest{
+				TeamID: req.TeamID,
+				UserID: req.UserID,
+				Role:   "player",
+			})
+		}
+	} else {
+		m, err = insertMember(ctx, tx, domains.AddMemberRequest{
+			TeamID: req.TeamID,
+			UserID: req.UserID,
+			Role:   "player",
+		})
+	}
 	if err != nil {
 		// Unique constraint violation: user is already on this team.
 		var pqErr *pq.Error

--- a/backend/internal/repository/team_repository.go
+++ b/backend/internal/repository/team_repository.go
@@ -206,10 +206,13 @@ func (r *teamRepository) DeleteTeam(ctx context.Context, req domains.DeleteTeamR
 	return domains.DeleteTeamResponse{}, nil
 }
 
-// RemoveMember deletes a team_members row by member ID (not user_id, to handle placeholders).
+// RemoveMember deletes a team_members row by member ID. Coaches cannot be removed.
 func (r *teamRepository) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {
-	const q = `DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`
-	result, err := r.db.ExecContext(ctx, q, req.TeamID, req.UserID)
+	// Delete by member ID; the role != 'coach' guard prevents removing the coach.
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM team_members WHERE id = $1 AND team_id = $2 AND role != 'coach'`,
+		req.MemberID, req.TeamID,
+	)
 	if err != nil {
 		return domains.RemoveMemberResponse{}, fmt.Errorf("remove member: %w", err)
 	}

--- a/backend/internal/repository/team_repository.go
+++ b/backend/internal/repository/team_repository.go
@@ -72,18 +72,19 @@ func insertTeam(ctx context.Context, tx *sql.Tx, req domains.CreateTeamRequest) 
 	return t, nil
 }
 
-// insertMember executes the INSERT into team_members within a transaction.
+// insertMember executes the INSERT into team_members with a required user_id (for coach creation).
 func insertMember(ctx context.Context, tx *sql.Tx, req domains.AddMemberRequest) (*models.TeamMember, error) {
 	const q = `
 		INSERT INTO team_members (team_id, user_id, role)
 		VALUES ($1, $2, $3)
-		RETURNING id, team_id, user_id, role, jersey_number, position, joined_at`
+		RETURNING id, team_id, user_id, name, role, jersey_number, position, joined_at`
 
 	m := &models.TeamMember{}
 	err := tx.QueryRowContext(ctx, q, req.TeamID, req.UserID, req.Role).Scan(
 		&m.ID,
 		&m.TeamID,
 		&m.UserID,
+		&m.Name,
 		&m.Role,
 		&m.JerseyNumber,
 		&m.Position,
@@ -205,7 +206,7 @@ func (r *teamRepository) DeleteTeam(ctx context.Context, req domains.DeleteTeamR
 	return domains.DeleteTeamResponse{}, nil
 }
 
-// RemoveMember deletes a team_members row for the given team+user pair.
+// RemoveMember deletes a team_members row by member ID (not user_id, to handle placeholders).
 func (r *teamRepository) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {
 	const q = `DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`
 	result, err := r.db.ExecContext(ctx, q, req.TeamID, req.UserID)
@@ -226,7 +227,7 @@ func (r *teamRepository) RemoveMember(ctx context.Context, req domains.RemoveMem
 // or ErrNotFound if no membership exists.
 func (r *teamRepository) GetMembership(ctx context.Context, req domains.GetMembershipRequest) (domains.GetMembershipResponse, error) {
 	const q = `
-		SELECT id, team_id, user_id, role, jersey_number, position, joined_at
+		SELECT id, team_id, user_id, name, role, jersey_number, position, joined_at
 		FROM team_members
 		WHERE team_id = $1 AND user_id = $2`
 
@@ -235,6 +236,7 @@ func (r *teamRepository) GetMembership(ctx context.Context, req domains.GetMembe
 		&m.ID,
 		&m.TeamID,
 		&m.UserID,
+		&m.Name,
 		&m.Role,
 		&m.JerseyNumber,
 		&m.Position,
@@ -249,14 +251,15 @@ func (r *teamRepository) GetMembership(ctx context.Context, req domains.GetMembe
 	return domains.GetMembershipResponse{Member: m}, nil
 }
 
-// ListMembers returns all members of a team joined with their user record.
+// ListMembers returns all members of a team. Placeholder slots (user_id IS NULL) are included;
+// their User pointer will be nil.
 func (r *teamRepository) ListMembers(ctx context.Context, req domains.ListMembersRequest) (domains.ListMembersResponse, error) {
 	const q = `
 		SELECT
-			tm.id, tm.team_id, tm.user_id, tm.role, tm.jersey_number, tm.position, tm.joined_at,
+			tm.id, tm.team_id, tm.user_id, tm.name, tm.role, tm.jersey_number, tm.position, tm.joined_at,
 			u.id, u.email, u.name, u.avatar_url, u.created_at
 		FROM team_members tm
-		JOIN users u ON u.id = tm.user_id
+		LEFT JOIN users u ON u.id = tm.user_id
 		WHERE tm.team_id = $1
 		ORDER BY tm.joined_at ASC`
 
@@ -269,21 +272,44 @@ func (r *teamRepository) ListMembers(ctx context.Context, req domains.ListMember
 	var members []domains.MemberWithUser
 	for rows.Next() {
 		var mwu domains.MemberWithUser
+		// Nullable user columns — user row may not exist for placeholder slots.
+		var (
+			userID        sql.NullString
+			userEmail     sql.NullString
+			userName      sql.NullString
+			userAvatarURL sql.NullString
+			userCreatedAt sql.NullTime
+		)
 		if err := rows.Scan(
 			&mwu.Member.ID,
 			&mwu.Member.TeamID,
 			&mwu.Member.UserID,
+			&mwu.Member.Name,
 			&mwu.Member.Role,
 			&mwu.Member.JerseyNumber,
 			&mwu.Member.Position,
 			&mwu.Member.JoinedAt,
-			&mwu.User.ID,
-			&mwu.User.Email,
-			&mwu.User.Name,
-			&mwu.User.AvatarURL,
-			&mwu.User.CreatedAt,
+			&userID,
+			&userEmail,
+			&userName,
+			&userAvatarURL,
+			&userCreatedAt,
 		); err != nil {
 			return domains.ListMembersResponse{}, fmt.Errorf("scan member row: %w", err)
+		}
+		if userID.Valid {
+			u := &models.User{
+				Email:     userEmail.String,
+				Name:      userName.String,
+				CreatedAt: userCreatedAt.Time,
+			}
+			if err := u.ID.UnmarshalText([]byte(userID.String)); err != nil {
+				return domains.ListMembersResponse{}, fmt.Errorf("parse user id: %w", err)
+			}
+			if userAvatarURL.Valid {
+				u.AvatarURL = &userAvatarURL.String
+			}
+			mwu.User = u
 		}
 		members = append(members, mwu)
 	}
@@ -295,4 +321,59 @@ func (r *teamRepository) ListMembers(ctx context.Context, req domains.ListMember
 		members = []domains.MemberWithUser{}
 	}
 	return domains.ListMembersResponse{Members: members}, nil
+}
+
+// AddRosterMember inserts a placeholder team_members row with no user_id.
+func (r *teamRepository) AddRosterMember(ctx context.Context, req domains.AddRosterMemberRequest) (domains.AddRosterMemberResponse, error) {
+	const q = `
+		INSERT INTO team_members (team_id, name, role, jersey_number, position)
+		VALUES ($1, $2, 'player', $3, $4)
+		RETURNING id, team_id, user_id, name, role, jersey_number, position, joined_at`
+
+	m := &models.TeamMember{}
+	err := r.db.QueryRowContext(ctx, q, req.TeamID, req.Name, req.JerseyNumber, req.Position).Scan(
+		&m.ID,
+		&m.TeamID,
+		&m.UserID,
+		&m.Name,
+		&m.Role,
+		&m.JerseyNumber,
+		&m.Position,
+		&m.JoinedAt,
+	)
+	if err != nil {
+		return domains.AddRosterMemberResponse{}, fmt.Errorf("add roster member: %w", err)
+	}
+	return domains.AddRosterMemberResponse{Member: m}, nil
+}
+
+// UpdateMember updates jersey_number, position, and/or name for an existing roster slot.
+func (r *teamRepository) UpdateMember(ctx context.Context, req domains.UpdateMemberRequest) (domains.UpdateMemberResponse, error) {
+	const q = `
+		UPDATE team_members
+		SET
+			jersey_number = COALESCE($1, jersey_number),
+			position      = COALESCE($2, position),
+			name          = COALESCE($3, name)
+		WHERE id = $4 AND team_id = $5
+		RETURNING id, team_id, user_id, name, role, jersey_number, position, joined_at`
+
+	m := &models.TeamMember{}
+	err := r.db.QueryRowContext(ctx, q, req.JerseyNumber, req.Position, req.Name, req.MemberID, req.TeamID).Scan(
+		&m.ID,
+		&m.TeamID,
+		&m.UserID,
+		&m.Name,
+		&m.Role,
+		&m.JerseyNumber,
+		&m.Position,
+		&m.JoinedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domains.UpdateMemberResponse{}, ErrNotFound
+	}
+	if err != nil {
+		return domains.UpdateMemberResponse{}, fmt.Errorf("update member: %w", err)
+	}
+	return domains.UpdateMemberResponse{Member: m}, nil
 }

--- a/backend/internal/usecase/game_usecase.go
+++ b/backend/internal/usecase/game_usecase.go
@@ -1,0 +1,174 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/omnia-core/sports-manager/backend/internal/domains"
+	"github.com/omnia-core/sports-manager/backend/internal/repository"
+)
+
+type gameUsecase struct {
+	repo     domains.GameRepository
+	teamRepo domains.TeamRepository
+}
+
+func NewGameUsecase(repo domains.GameRepository, teamRepo domains.TeamRepository) domains.GameUsecase {
+	return &gameUsecase{repo: repo, teamRepo: teamRepo}
+}
+
+func (u *gameUsecase) CreateGame(ctx context.Context, req domains.CreateGameRequest) (domains.CreateGameResponse, error) {
+	req.OpponentName = strings.TrimSpace(req.OpponentName)
+	if req.OpponentName == "" {
+		return domains.CreateGameResponse{}, ErrNameRequired
+	}
+
+	if err := requireCoach(ctx, u.teamRepo, req.TeamID, req.CallerID); err != nil {
+		return domains.CreateGameResponse{}, err
+	}
+
+	res, err := u.repo.CreateGame(ctx, req)
+	if err != nil {
+		return domains.CreateGameResponse{}, fmt.Errorf("create game: %w", err)
+	}
+
+	membersRes, err := u.teamRepo.ListMembers(ctx, domains.ListMembersRequest{TeamID: req.TeamID, CallerID: req.CallerID})
+	if err != nil {
+		return domains.CreateGameResponse{}, fmt.Errorf("list members for seed: %w", err)
+	}
+
+	seedReq := domains.SeedGamePlayersRequest{GameID: res.Game.ID}
+	for _, mwu := range membersRes.Members {
+		seedReq.UserIDs = append(seedReq.UserIDs, mwu.Member.UserID)
+	}
+	if _, err := u.repo.SeedGamePlayers(ctx, seedReq); err != nil {
+		return domains.CreateGameResponse{}, fmt.Errorf("seed game players: %w", err)
+	}
+
+	return res, nil
+}
+
+func (u *gameUsecase) ListGames(ctx context.Context, req domains.ListGamesRequest) (domains.ListGamesResponse, error) {
+	if err := requireMember(ctx, u.teamRepo, req.TeamID, req.CallerID); err != nil {
+		return domains.ListGamesResponse{}, err
+	}
+	res, err := u.repo.ListGames(ctx, req)
+	if err != nil {
+		return domains.ListGamesResponse{}, fmt.Errorf("list games: %w", err)
+	}
+	return res, nil
+}
+
+func (u *gameUsecase) GetGameDetail(ctx context.Context, req domains.GetGameDetailRequest) (domains.GetGameDetailResponse, error) {
+	gameRes, err := u.repo.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID, CallerID: req.CallerID})
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.GetGameDetailResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.GetGameDetailResponse{}, fmt.Errorf("get game for detail: %w", err)
+	}
+
+	if err := requireMember(ctx, u.teamRepo, gameRes.Game.TeamID, req.CallerID); err != nil {
+		return domains.GetGameDetailResponse{}, err
+	}
+
+	res, err := u.repo.GetGameDetail(ctx, req)
+	if err != nil {
+		return domains.GetGameDetailResponse{}, fmt.Errorf("get game detail: %w", err)
+	}
+	return res, nil
+}
+
+func (u *gameUsecase) UpdateGame(ctx context.Context, req domains.UpdateGameRequest) (domains.UpdateGameResponse, error) {
+	gameRes, err := u.repo.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID, CallerID: req.CallerID})
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.UpdateGameResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.UpdateGameResponse{}, fmt.Errorf("get game for update: %w", err)
+	}
+
+	if err := requireCoach(ctx, u.teamRepo, gameRes.Game.TeamID, req.CallerID); err != nil {
+		return domains.UpdateGameResponse{}, err
+	}
+
+	res, err := u.repo.UpdateGame(ctx, req)
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.UpdateGameResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.UpdateGameResponse{}, fmt.Errorf("update game: %w", err)
+	}
+	return res, nil
+}
+
+func (u *gameUsecase) DeleteGame(ctx context.Context, req domains.DeleteGameRequest) (domains.DeleteGameResponse, error) {
+	gameRes, err := u.repo.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID, CallerID: req.CallerID})
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.DeleteGameResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.DeleteGameResponse{}, fmt.Errorf("get game for delete: %w", err)
+	}
+
+	if err := requireCoach(ctx, u.teamRepo, gameRes.Game.TeamID, req.CallerID); err != nil {
+		return domains.DeleteGameResponse{}, err
+	}
+
+	res, err := u.repo.DeleteGame(ctx, req)
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.DeleteGameResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.DeleteGameResponse{}, fmt.Errorf("delete game: %w", err)
+	}
+	return res, nil
+}
+
+func (u *gameUsecase) UpsertStats(ctx context.Context, req domains.UpsertStatsRequest) (domains.UpsertStatsResponse, error) {
+	gameRes, err := u.repo.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID, CallerID: req.CallerID})
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.UpsertStatsResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.UpsertStatsResponse{}, fmt.Errorf("get game for upsert stats: %w", err)
+	}
+
+	if err := requireCoach(ctx, u.teamRepo, gameRes.Game.TeamID, req.CallerID); err != nil {
+		return domains.UpsertStatsResponse{}, err
+	}
+
+	res, err := u.repo.UpsertStats(ctx, req)
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.UpsertStatsResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.UpsertStatsResponse{}, fmt.Errorf("upsert stats: %w", err)
+	}
+	return res, nil
+}
+
+func (u *gameUsecase) ToggleDNP(ctx context.Context, req domains.ToggleDNPRequest) (domains.ToggleDNPResponse, error) {
+	gameRes, err := u.repo.GetGame(ctx, domains.GetGameRequest{GameID: req.GameID, CallerID: req.CallerID})
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.ToggleDNPResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.ToggleDNPResponse{}, fmt.Errorf("get game for toggle dnp: %w", err)
+	}
+
+	if err := requireCoach(ctx, u.teamRepo, gameRes.Game.TeamID, req.CallerID); err != nil {
+		return domains.ToggleDNPResponse{}, err
+	}
+
+	res, err := u.repo.ToggleDNP(ctx, req)
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.ToggleDNPResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.ToggleDNPResponse{}, fmt.Errorf("toggle dnp: %w", err)
+	}
+	return res, nil
+}

--- a/backend/internal/usecase/game_usecase.go
+++ b/backend/internal/usecase/game_usecase.go
@@ -78,6 +78,23 @@ func (u *gameUsecase) GetGameDetail(ctx context.Context, req domains.GetGameDeta
 		return domains.GetGameDetailResponse{}, err
 	}
 
+	// Seed any team members added after game creation. ON CONFLICT DO NOTHING makes this idempotent.
+	membersRes, err := u.teamRepo.ListMembers(ctx, domains.ListMembersRequest{TeamID: gameRes.Game.TeamID, CallerID: req.CallerID})
+	if err != nil {
+		return domains.GetGameDetailResponse{}, fmt.Errorf("list members for reseed: %w", err)
+	}
+	seedReq := domains.SeedGamePlayersRequest{GameID: req.GameID}
+	for _, mwu := range membersRes.Members {
+		if mwu.Member.UserID != nil {
+			seedReq.UserIDs = append(seedReq.UserIDs, *mwu.Member.UserID)
+		}
+	}
+	if len(seedReq.UserIDs) > 0 {
+		if _, err := u.repo.SeedGamePlayers(ctx, seedReq); err != nil {
+			return domains.GetGameDetailResponse{}, fmt.Errorf("reseed game players: %w", err)
+		}
+	}
+
 	res, err := u.repo.GetGameDetail(ctx, req)
 	if err != nil {
 		return domains.GetGameDetailResponse{}, fmt.Errorf("get game detail: %w", err)

--- a/backend/internal/usecase/game_usecase.go
+++ b/backend/internal/usecase/game_usecase.go
@@ -41,11 +41,7 @@ func (u *gameUsecase) CreateGame(ctx context.Context, req domains.CreateGameRequ
 
 	seedReq := domains.SeedGamePlayersRequest{GameID: res.Game.ID}
 	for _, mwu := range membersRes.Members {
-		// Skip placeholder slots — only seed members with a linked user account.
-		if mwu.Member.UserID == nil {
-			continue
-		}
-		seedReq.UserIDs = append(seedReq.UserIDs, *mwu.Member.UserID)
+		seedReq.MemberIDs = append(seedReq.MemberIDs, mwu.Member.ID)
 	}
 	if _, err := u.repo.SeedGamePlayers(ctx, seedReq); err != nil {
 		return domains.CreateGameResponse{}, fmt.Errorf("seed game players: %w", err)
@@ -85,11 +81,9 @@ func (u *gameUsecase) GetGameDetail(ctx context.Context, req domains.GetGameDeta
 	}
 	seedReq := domains.SeedGamePlayersRequest{GameID: req.GameID}
 	for _, mwu := range membersRes.Members {
-		if mwu.Member.UserID != nil {
-			seedReq.UserIDs = append(seedReq.UserIDs, *mwu.Member.UserID)
-		}
+		seedReq.MemberIDs = append(seedReq.MemberIDs, mwu.Member.ID)
 	}
-	if len(seedReq.UserIDs) > 0 {
+	if len(seedReq.MemberIDs) > 0 {
 		if _, err := u.repo.SeedGamePlayers(ctx, seedReq); err != nil {
 			return domains.GetGameDetailResponse{}, fmt.Errorf("reseed game players: %w", err)
 		}

--- a/backend/internal/usecase/game_usecase.go
+++ b/backend/internal/usecase/game_usecase.go
@@ -41,7 +41,11 @@ func (u *gameUsecase) CreateGame(ctx context.Context, req domains.CreateGameRequ
 
 	seedReq := domains.SeedGamePlayersRequest{GameID: res.Game.ID}
 	for _, mwu := range membersRes.Members {
-		seedReq.UserIDs = append(seedReq.UserIDs, mwu.Member.UserID)
+		// Skip placeholder slots — only seed members with a linked user account.
+		if mwu.Member.UserID == nil {
+			continue
+		}
+		seedReq.UserIDs = append(seedReq.UserIDs, *mwu.Member.UserID)
 	}
 	if _, err := u.repo.SeedGamePlayers(ctx, seedReq); err != nil {
 		return domains.CreateGameResponse{}, fmt.Errorf("seed game players: %w", err)

--- a/backend/internal/usecase/game_usecase_test.go
+++ b/backend/internal/usecase/game_usecase_test.go
@@ -77,6 +77,12 @@ func (f *fakeTeamRepo) DeleteTeam(ctx context.Context, req domains.DeleteTeamReq
 func (f *fakeTeamRepo) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {
 	return domains.RemoveMemberResponse{}, nil
 }
+func (f *fakeTeamRepo) AddRosterMember(ctx context.Context, req domains.AddRosterMemberRequest) (domains.AddRosterMemberResponse, error) {
+	return domains.AddRosterMemberResponse{}, nil
+}
+func (f *fakeTeamRepo) UpdateMember(ctx context.Context, req domains.UpdateMemberRequest) (domains.UpdateMemberResponse, error) {
+	return domains.UpdateMemberResponse{}, nil
+}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/backend/internal/usecase/game_usecase_test.go
+++ b/backend/internal/usecase/game_usecase_test.go
@@ -1,0 +1,149 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/omnia-core/sports-manager/backend/internal/domains"
+	"github.com/omnia-core/sports-manager/backend/internal/models"
+	"github.com/omnia-core/sports-manager/backend/internal/repository"
+	"github.com/omnia-core/sports-manager/backend/internal/usecase"
+)
+
+// ── Minimal fakes ────────────────────────────────────────────────────────────
+
+type fakeGameRepo struct {
+	createFn func(ctx context.Context, req domains.CreateGameRequest) (domains.CreateGameResponse, error)
+	seedFn   func(ctx context.Context, req domains.SeedGamePlayersRequest) (domains.SeedGamePlayersResponse, error)
+}
+
+func (f *fakeGameRepo) CreateGame(ctx context.Context, req domains.CreateGameRequest) (domains.CreateGameResponse, error) {
+	return f.createFn(ctx, req)
+}
+func (f *fakeGameRepo) SeedGamePlayers(ctx context.Context, req domains.SeedGamePlayersRequest) (domains.SeedGamePlayersResponse, error) {
+	return f.seedFn(ctx, req)
+}
+func (f *fakeGameRepo) GetGame(ctx context.Context, req domains.GetGameRequest) (domains.GetGameResponse, error) {
+	return domains.GetGameResponse{}, nil
+}
+func (f *fakeGameRepo) ListGames(ctx context.Context, req domains.ListGamesRequest) (domains.ListGamesResponse, error) {
+	return domains.ListGamesResponse{Games: []*models.Game{}}, nil
+}
+func (f *fakeGameRepo) GetGameDetail(ctx context.Context, req domains.GetGameDetailRequest) (domains.GetGameDetailResponse, error) {
+	return domains.GetGameDetailResponse{}, nil
+}
+func (f *fakeGameRepo) UpdateGame(ctx context.Context, req domains.UpdateGameRequest) (domains.UpdateGameResponse, error) {
+	return domains.UpdateGameResponse{}, nil
+}
+func (f *fakeGameRepo) DeleteGame(ctx context.Context, req domains.DeleteGameRequest) (domains.DeleteGameResponse, error) {
+	return domains.DeleteGameResponse{}, nil
+}
+func (f *fakeGameRepo) UpsertStats(ctx context.Context, req domains.UpsertStatsRequest) (domains.UpsertStatsResponse, error) {
+	return domains.UpsertStatsResponse{}, nil
+}
+func (f *fakeGameRepo) ToggleDNP(ctx context.Context, req domains.ToggleDNPRequest) (domains.ToggleDNPResponse, error) {
+	return domains.ToggleDNPResponse{}, nil
+}
+
+type fakeTeamRepo struct {
+	getMembershipFn func(ctx context.Context, req domains.GetMembershipRequest) (domains.GetMembershipResponse, error)
+	listMembersFn   func(ctx context.Context, req domains.ListMembersRequest) (domains.ListMembersResponse, error)
+}
+
+func (f *fakeTeamRepo) GetMembership(ctx context.Context, req domains.GetMembershipRequest) (domains.GetMembershipResponse, error) {
+	return f.getMembershipFn(ctx, req)
+}
+func (f *fakeTeamRepo) ListMembers(ctx context.Context, req domains.ListMembersRequest) (domains.ListMembersResponse, error) {
+	return f.listMembersFn(ctx, req)
+}
+func (f *fakeTeamRepo) CreateTeam(ctx context.Context, req domains.CreateTeamRequest) (domains.CreateTeamResponse, error) {
+	return domains.CreateTeamResponse{}, nil
+}
+func (f *fakeTeamRepo) GetTeam(ctx context.Context, req domains.GetTeamRequest) (domains.GetTeamResponse, error) {
+	return domains.GetTeamResponse{}, nil
+}
+func (f *fakeTeamRepo) ListTeams(ctx context.Context, req domains.ListTeamsRequest) (domains.ListTeamsResponse, error) {
+	return domains.ListTeamsResponse{}, nil
+}
+func (f *fakeTeamRepo) UpdateTeam(ctx context.Context, req domains.UpdateTeamRequest) (domains.UpdateTeamResponse, error) {
+	return domains.UpdateTeamResponse{}, nil
+}
+func (f *fakeTeamRepo) DeleteTeam(ctx context.Context, req domains.DeleteTeamRequest) (domains.DeleteTeamResponse, error) {
+	return domains.DeleteTeamResponse{}, nil
+}
+func (f *fakeTeamRepo) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {
+	return domains.RemoveMemberResponse{}, nil
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+func TestCreateGame_EmptyOpponent_ReturnsError(t *testing.T) {
+	coachID := uuid.New()
+	teamID := uuid.New()
+
+	teamRepo := &fakeTeamRepo{
+		getMembershipFn: func(_ context.Context, req domains.GetMembershipRequest) (domains.GetMembershipResponse, error) {
+			return domains.GetMembershipResponse{Member: &models.TeamMember{Role: models.RoleCoach}}, nil
+		},
+		listMembersFn: func(_ context.Context, _ domains.ListMembersRequest) (domains.ListMembersResponse, error) {
+			return domains.ListMembersResponse{Members: []domains.MemberWithUser{}}, nil
+		},
+	}
+	gameRepo := &fakeGameRepo{}
+
+	uc := usecase.NewGameUsecase(gameRepo, teamRepo)
+
+	_, err := uc.CreateGame(context.Background(), domains.CreateGameRequest{
+		TeamID:       teamID,
+		CallerID:     coachID,
+		OpponentName: "   ", // whitespace only
+		GameDate:     time.Now(),
+	})
+
+	if err == nil {
+		t.Fatal("expected error for empty opponent name, got nil")
+	}
+	if !errors.Is(err, usecase.ErrNameRequired) {
+		t.Fatalf("expected ErrNameRequired, got %v", err)
+	}
+}
+
+func TestCreateGame_NonCoach_ReturnsForbidden(t *testing.T) {
+	playerID := uuid.New()
+	teamID := uuid.New()
+
+	teamRepo := &fakeTeamRepo{
+		getMembershipFn: func(_ context.Context, _ domains.GetMembershipRequest) (domains.GetMembershipResponse, error) {
+			return domains.GetMembershipResponse{Member: &models.TeamMember{Role: models.RolePlayer}}, nil
+		},
+		listMembersFn: func(_ context.Context, _ domains.ListMembersRequest) (domains.ListMembersResponse, error) {
+			return domains.ListMembersResponse{}, nil
+		},
+	}
+	gameRepo := &fakeGameRepo{}
+
+	uc := usecase.NewGameUsecase(gameRepo, teamRepo)
+
+	_, err := uc.CreateGame(context.Background(), domains.CreateGameRequest{
+		TeamID:       teamID,
+		CallerID:     playerID,
+		OpponentName: "Lakers",
+		GameDate:     time.Now(),
+	})
+
+	if !errors.Is(err, usecase.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+// Ensure the fakeTeamRepo satisfies domains.TeamRepository at compile time.
+var _ domains.TeamRepository = (*fakeTeamRepo)(nil)
+
+// Ensure the fakeGameRepo satisfies domains.GameRepository at compile time.
+var _ domains.GameRepository = (*fakeGameRepo)(nil)
+
+// Suppress unused import for repository package (used indirectly via ErrNotFound).
+var _ = repository.ErrNotFound

--- a/backend/internal/usecase/invite_usecase.go
+++ b/backend/internal/usecase/invite_usecase.go
@@ -89,10 +89,11 @@ func (u *inviteUsecase) CreateInvite(ctx context.Context, req domains.CreateInvi
 		return domains.CreateInviteResponse{}, fmt.Errorf("get team: %w", err)
 	}
 
-	// Persist invite — forward only the fields the repository needs.
+	// Persist invite — forward the fields the repository needs.
 	createRes, err := u.inviteRepo.CreateInvite(ctx, domains.CreateInviteRequest{
-		TeamID: req.TeamID,
-		Email:  req.Email,
+		TeamID:       req.TeamID,
+		Email:        req.Email,
+		TeamMemberID: req.TeamMemberID,
 	})
 	if err != nil {
 		return domains.CreateInviteResponse{}, fmt.Errorf("create invite: %w", err)
@@ -124,10 +125,11 @@ func (u *inviteUsecase) AcceptInvite(ctx context.Context, req domains.AcceptInvi
 	}
 
 	atomicRes, err := u.inviteRepo.AcceptInviteAtomic(ctx, domains.AcceptInviteAtomicRequest{
-		InviteID:  inv.ID,
-		TeamID:    inv.TeamID,
-		UserID:    req.UserID,
-		ExpiresAt: inv.ExpiresAt,
+		InviteID:     inv.ID,
+		TeamID:       inv.TeamID,
+		UserID:       req.UserID,
+		TeamMemberID: inv.TeamMemberID,
+		ExpiresAt:    inv.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, repository.ErrAlreadyMember) {

--- a/backend/internal/usecase/team_usecase.go
+++ b/backend/internal/usecase/team_usecase.go
@@ -120,6 +120,39 @@ func (u *teamUsecase) ListMembers(ctx context.Context, req domains.ListMembersRe
 	return res, nil
 }
 
+// AddRosterMember verifies the caller is a coach, then inserts a placeholder
+// roster slot (no user account required).
+func (u *teamUsecase) AddRosterMember(ctx context.Context, req domains.AddRosterMemberRequest) (domains.AddRosterMemberResponse, error) {
+	if err := requireCoach(ctx, u.repo, req.TeamID, req.CallerID); err != nil {
+		return domains.AddRosterMemberResponse{}, err
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		return domains.AddRosterMemberResponse{}, ErrNameRequired
+	}
+	res, err := u.repo.AddRosterMember(ctx, req)
+	if err != nil {
+		return domains.AddRosterMemberResponse{}, fmt.Errorf("add roster member: %w", err)
+	}
+	return res, nil
+}
+
+// UpdateMember verifies the caller is a coach, then updates jersey/position/name
+// for the given roster slot.
+func (u *teamUsecase) UpdateMember(ctx context.Context, req domains.UpdateMemberRequest) (domains.UpdateMemberResponse, error) {
+	if err := requireCoach(ctx, u.repo, req.TeamID, req.CallerID); err != nil {
+		return domains.UpdateMemberResponse{}, err
+	}
+	res, err := u.repo.UpdateMember(ctx, req)
+	if errors.Is(err, repository.ErrNotFound) {
+		return domains.UpdateMemberResponse{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return domains.UpdateMemberResponse{}, fmt.Errorf("update member: %w", err)
+	}
+	return res, nil
+}
+
 // RemoveMember verifies the caller is a coach, prevents removing the coach,
 // then removes the target user from the team.
 func (u *teamUsecase) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {

--- a/backend/internal/usecase/team_usecase.go
+++ b/backend/internal/usecase/team_usecase.go
@@ -153,20 +153,11 @@ func (u *teamUsecase) UpdateMember(ctx context.Context, req domains.UpdateMember
 	return res, nil
 }
 
-// RemoveMember verifies the caller is a coach, prevents removing the coach,
-// then removes the target user from the team.
+// RemoveMember verifies the caller is a coach, then removes the target member.
+// The repository rejects attempts to remove a coach-role member.
 func (u *teamUsecase) RemoveMember(ctx context.Context, req domains.RemoveMemberRequest) (domains.RemoveMemberResponse, error) {
 	if err := requireCoach(ctx, u.repo, req.TeamID, req.CallerID); err != nil {
 		return domains.RemoveMemberResponse{}, err
-	}
-
-	// Prevent removing the coach from their own team.
-	teamRes, err := u.repo.GetTeam(ctx, domains.GetTeamRequest{TeamID: req.TeamID, CallerID: req.CallerID})
-	if err != nil {
-		return domains.RemoveMemberResponse{}, fmt.Errorf("get team: %w", err)
-	}
-	if teamRes.Team.CoachID == req.UserID {
-		return domains.RemoveMemberResponse{}, ErrCannotRemoveCoach
 	}
 
 	res, err := u.repo.RemoveMember(ctx, req)

--- a/backend/migrations/000007_create_games.down.sql
+++ b/backend/migrations/000007_create_games.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS game_stats;
+DROP TABLE IF EXISTS game_players;
+DROP TABLE IF EXISTS games;

--- a/backend/migrations/000007_create_games.up.sql
+++ b/backend/migrations/000007_create_games.up.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS games (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id        UUID        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    opponent_name  TEXT        NOT NULL,
+    game_date      DATE        NOT NULL,
+    team_score     INT,
+    opponent_score INT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_games_team_id ON games(team_id);
+
+CREATE TABLE IF NOT EXISTS game_players (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    game_id    UUID        NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    is_dnp     BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (game_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_game_players_game_id ON game_players(game_id);
+
+CREATE TABLE IF NOT EXISTS game_stats (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    game_player_id UUID NOT NULL REFERENCES game_players(id) ON DELETE CASCADE UNIQUE,
+    mins           INT  NOT NULL DEFAULT 0,
+    pts            INT  NOT NULL DEFAULT 0,
+    fgm            INT  NOT NULL DEFAULT 0,
+    fga            INT  NOT NULL DEFAULT 0,
+    three_pm       INT  NOT NULL DEFAULT 0,
+    three_pa       INT  NOT NULL DEFAULT 0,
+    ftm            INT  NOT NULL DEFAULT 0,
+    fta            INT  NOT NULL DEFAULT 0,
+    orb            INT  NOT NULL DEFAULT 0,
+    drb            INT  NOT NULL DEFAULT 0,
+    ast            INT  NOT NULL DEFAULT 0,
+    stl            INT  NOT NULL DEFAULT 0,
+    blk            INT  NOT NULL DEFAULT 0,
+    tov            INT  NOT NULL DEFAULT 0,
+    pf             INT  NOT NULL DEFAULT 0,
+    plus_minus     INT  NOT NULL DEFAULT 0
+);

--- a/backend/migrations/000008_roster_slots.down.sql
+++ b/backend/migrations/000008_roster_slots.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE team_invites DROP COLUMN IF EXISTS team_member_id;
+DROP INDEX IF EXISTS team_members_team_user_unique;
+ALTER TABLE team_members DROP COLUMN IF EXISTS name;
+ALTER TABLE team_members ALTER COLUMN user_id SET NOT NULL;

--- a/backend/migrations/000008_roster_slots.down.sql
+++ b/backend/migrations/000008_roster_slots.down.sql
@@ -2,3 +2,4 @@ ALTER TABLE team_invites DROP COLUMN IF EXISTS team_member_id;
 DROP INDEX IF EXISTS team_members_team_user_unique;
 ALTER TABLE team_members DROP COLUMN IF EXISTS name;
 ALTER TABLE team_members ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE team_members ADD CONSTRAINT team_members_team_id_user_id_key UNIQUE (team_id, user_id);

--- a/backend/migrations/000008_roster_slots.up.sql
+++ b/backend/migrations/000008_roster_slots.up.sql
@@ -1,0 +1,20 @@
+-- Make user_id nullable so coaches can add placeholder roster slots
+ALTER TABLE team_members
+    ALTER COLUMN user_id DROP NOT NULL;
+
+-- Add a display name for placeholder members (also stores real name for linked members)
+ALTER TABLE team_members
+    ADD COLUMN name TEXT;
+
+-- Enforce uniqueness only when a user_id is actually assigned
+CREATE UNIQUE INDEX team_members_team_user_unique
+    ON team_members (team_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+-- Drop the old NOT NULL unique constraint if it exists as a separate index
+-- (the original migration used a UNIQUE constraint inline; this drops the implicit index)
+DROP INDEX IF EXISTS team_members_team_id_user_id_key;
+
+-- Link invites to a specific roster slot (optional)
+ALTER TABLE team_invites
+    ADD COLUMN team_member_id UUID REFERENCES team_members(id) ON DELETE SET NULL;

--- a/backend/migrations/000008_roster_slots.up.sql
+++ b/backend/migrations/000008_roster_slots.up.sql
@@ -11,9 +11,8 @@ CREATE UNIQUE INDEX team_members_team_user_unique
     ON team_members (team_id, user_id)
     WHERE user_id IS NOT NULL;
 
--- Drop the old NOT NULL unique constraint if it exists as a separate index
--- (the original migration used a UNIQUE constraint inline; this drops the implicit index)
-DROP INDEX IF EXISTS team_members_team_id_user_id_key;
+-- Drop the old UNIQUE constraint (created inline in the original migration)
+ALTER TABLE team_members DROP CONSTRAINT IF EXISTS team_members_team_id_user_id_key;
 
 -- Link invites to a specific roster slot (optional)
 ALTER TABLE team_invites

--- a/backend/migrations/000009_game_players_use_member_id.down.sql
+++ b/backend/migrations/000009_game_players_use_member_id.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE game_players ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE game_players DROP CONSTRAINT IF EXISTS game_players_game_id_member_id_key;
+ALTER TABLE game_players ADD CONSTRAINT game_players_game_id_user_id_key UNIQUE (game_id, user_id);
+ALTER TABLE game_players DROP COLUMN IF EXISTS team_member_id;

--- a/backend/migrations/000009_game_players_use_member_id.up.sql
+++ b/backend/migrations/000009_game_players_use_member_id.up.sql
@@ -1,0 +1,24 @@
+-- Add team_member_id to game_players so ALL roster members (including placeholders) can be tracked.
+ALTER TABLE game_players
+    ADD COLUMN team_member_id UUID REFERENCES team_members(id) ON DELETE CASCADE;
+
+-- Backfill team_member_id from team_members using the game's team_id.
+UPDATE game_players
+SET team_member_id = (
+    SELECT tm.id
+    FROM team_members tm
+    JOIN games g ON g.team_id = tm.team_id
+    WHERE g.id = game_players.game_id
+      AND tm.user_id = game_players.user_id
+    LIMIT 1
+);
+
+-- Make team_member_id mandatory now that it's backfilled.
+ALTER TABLE game_players ALTER COLUMN team_member_id SET NOT NULL;
+
+-- Drop the old (game_id, user_id) unique constraint and add (game_id, team_member_id).
+ALTER TABLE game_players DROP CONSTRAINT game_players_game_id_user_id_key;
+ALTER TABLE game_players ADD CONSTRAINT game_players_game_id_member_id_key UNIQUE (game_id, team_member_id);
+
+-- user_id is now informational only (kept for reference, nullable for placeholder members).
+ALTER TABLE game_players ALTER COLUMN user_id DROP NOT NULL;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import RegisterPage from './pages/auth/RegisterPage'
 import AcceptInvitePage from './pages/auth/AcceptInvitePage'
 import TeamsPage from './pages/teams/TeamsPage'
 import TeamDetailPage from './pages/teams/TeamDetailPage'
+import GameDetailPage from './pages/teams/GameDetailPage'
 import PlaybookPage from './pages/playbooks/PlaybookPage'
 
 // Lazy-load the Konva editor so it doesn't bloat the main bundle
@@ -72,6 +73,16 @@ function AppRoutes() {
               <Suspense fallback={<div className="flex min-h-[60vh] items-center justify-center"><Spinner size="lg" /></div>}>
                 <PlayEditorPage />
               </Suspense>
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/games/:gameID"
+        element={
+          <ProtectedRoute>
+            <Layout>
+              <GameDetailPage />
             </Layout>
           </ProtectedRoute>
         }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -78,3 +78,8 @@ export async function del<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE_URL}${path}`, buildRequest('DELETE'))
   return handleResponse<T>(res)
 }
+
+export async function patch<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, buildRequest('PATCH', body))
+  return handleResponse<T>(res)
+}

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -1,0 +1,35 @@
+import { get, post, put, patch, del } from './client'
+import type { Game, GameDetail, GameStats } from '../types'
+
+export const gamesApi = {
+  list(teamID: string): Promise<{ games: Game[] }> {
+    return get<{ games: Game[] }>(`/api/teams/${teamID}/games`)
+  },
+
+  create(teamID: string, data: { opponent_name: string; game_date: string }): Promise<Game> {
+    return post<Game>(`/api/teams/${teamID}/games`, data)
+  },
+
+  getDetail(gameID: string): Promise<GameDetail> {
+    return get<GameDetail>(`/api/games/${gameID}`)
+  },
+
+  update(
+    gameID: string,
+    data: { opponent_name?: string; game_date?: string; team_score?: number | null; opponent_score?: number | null },
+  ): Promise<Game> {
+    return put<Game>(`/api/games/${gameID}`, data)
+  },
+
+  remove(gameID: string): Promise<void> {
+    return del<void>(`/api/games/${gameID}`)
+  },
+
+  upsertStats(gameID: string, userID: string, stats: GameStats): Promise<GameStats> {
+    return put<GameStats>(`/api/games/${gameID}/stats/${userID}`, stats)
+  },
+
+  toggleDNP(gameID: string, userID: string): Promise<{ is_dnp: boolean }> {
+    return patch<{ is_dnp: boolean }>(`/api/games/${gameID}/players/${userID}`)
+  },
+}

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -25,11 +25,11 @@ export const gamesApi = {
     return del<void>(`/api/games/${gameID}`)
   },
 
-  upsertStats(gameID: string, userID: string, stats: GameStats): Promise<GameStats> {
-    return put<GameStats>(`/api/games/${gameID}/stats/${userID}`, stats)
+  upsertStats(gameID: string, memberID: string, stats: GameStats): Promise<GameStats> {
+    return put<GameStats>(`/api/games/${gameID}/stats/${memberID}`, stats)
   },
 
-  toggleDNP(gameID: string, userID: string): Promise<{ is_dnp: boolean }> {
-    return patch<{ is_dnp: boolean }>(`/api/games/${gameID}/players/${userID}`)
+  toggleDNP(gameID: string, memberID: string): Promise<{ is_dnp: boolean }> {
+    return patch<{ is_dnp: boolean }>(`/api/games/${gameID}/players/${memberID}`)
   },
 }

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -30,8 +30,8 @@ export const teamsApi = {
     return post<void>(`/api/teams/${teamID}/members`, { email, member_id: memberID ?? undefined })
   },
 
-  removeMember(teamID: string, userID: string): Promise<void> {
-    return del<void>(`/api/teams/${teamID}/members/${userID}`)
+  removeMember(teamID: string, memberID: string): Promise<void> {
+    return del<void>(`/api/teams/${teamID}/members/${memberID}`)
   },
 
   addRosterMember(teamID: string, data: { name: string; jersey_number?: number | null; position?: string | null }): Promise<TeamMember> {

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -1,5 +1,5 @@
 import { get, post, put, del } from './client'
-import type { Team, MemberWithUser } from '../types'
+import type { Team, TeamMember, MemberWithUser } from '../types'
 
 export const teamsApi = {
   list(): Promise<{ teams: Team[] }> {
@@ -26,11 +26,19 @@ export const teamsApi = {
     return get<{ members: MemberWithUser[] }>(`/api/teams/${teamID}/members`)
   },
 
-  inviteMember(teamID: string, email: string): Promise<void> {
-    return post<void>(`/api/teams/${teamID}/members`, { email })
+  inviteMember(teamID: string, email: string, memberID?: string): Promise<void> {
+    return post<void>(`/api/teams/${teamID}/members`, { email, member_id: memberID ?? undefined })
   },
 
   removeMember(teamID: string, userID: string): Promise<void> {
     return del<void>(`/api/teams/${teamID}/members/${userID}`)
+  },
+
+  addRosterMember(teamID: string, data: { name: string; jersey_number?: number | null; position?: string | null }): Promise<TeamMember> {
+    return post<TeamMember>(`/api/teams/${teamID}/roster`, data)
+  },
+
+  updateMember(teamID: string, memberID: string, data: { jersey_number?: number | null; position?: string | null; name?: string }): Promise<TeamMember> {
+    return put<TeamMember>(`/api/teams/${teamID}/members/${memberID}`, data)
   },
 }

--- a/frontend/src/pages/teams/GameDetailPage.tsx
+++ b/frontend/src/pages/teams/GameDetailPage.tsx
@@ -167,7 +167,7 @@ function BoxScoreTable({
 
 type LivePanelStat =
   | { type: 'pts2' } | { type: 'pts3' } | { type: 'ftMade' } | { type: 'ftMiss' }
-  | { type: 'fgMade' } | { type: 'fgMiss' }
+  | { type: 'fgMade' } | { type: 'fgMiss' } | { type: '3pMiss' }
   | { type: 'orbReb' } | { type: 'drbReb' }
   | { type: 'ast' } | { type: 'stl' } | { type: 'blk' } | { type: 'tov' } | { type: 'foul' }
 
@@ -180,6 +180,7 @@ function applyLiveStat(current: GameStats, action: LivePanelStat): GameStats {
     case 'ftMiss': s.fta += 1; break
     case 'fgMade': s.fgm += 1; s.fga += 1; break
     case 'fgMiss': s.fga += 1; break
+    case '3pMiss': s.three_pa += 1; s.fga += 1; break
     case 'orbReb': s.orb += 1; break
     case 'drbReb': s.drb += 1; break
     case 'ast':  s.ast += 1; break
@@ -230,7 +231,9 @@ function LivePanel({
 
           <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'fgMade' })}>FG ✓</button>
           <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'fgMiss' })}>FG ✗</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: '3pMiss' })}>3P ✗</button>
           <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'orbReb' })}>ORB</button>
+
           <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'drbReb' })}>DRB</button>
 
           <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'ast' })}>AST</button>
@@ -254,9 +257,11 @@ function LiveMode({
   onAction: (userID: string, action: LivePanelStat) => void
   onToggleDNP: (userID: string) => Promise<void>
 }) {
-  const [activePlayer, setActivePlayer] = useState<GamePlayer | null>(null)
+  const [activePlayerID, setActivePlayerID] = useState<string | null>(null)
   const active = players.filter((p) => !p.is_dnp)
   const dnp = players.filter((p) => p.is_dnp)
+  // Derive from props so the panel always shows the latest stats from the store
+  const activePlayer = activePlayerID ? (players.find((p) => p.user_id === activePlayerID) ?? null) : null
 
   return (
     <div>
@@ -266,7 +271,7 @@ function LiveMode({
           return (
             <button
               key={player.user_id}
-              onClick={() => setActivePlayer(player)}
+              onClick={() => setActivePlayerID(player.user_id)}
               className="flex flex-col gap-1 rounded-xl border border-secondary/20 bg-primary p-4 text-left transition-colors hover:border-secondary/40"
             >
               <div className="flex items-center gap-2">
@@ -308,7 +313,7 @@ function LiveMode({
           onAction={(action) => {
             onAction(activePlayer.user_id, action)
           }}
-          onClose={() => setActivePlayer(null)}
+          onClose={() => setActivePlayerID(null)}
         />
       )}
     </div>

--- a/frontend/src/pages/teams/GameDetailPage.tsx
+++ b/frontend/src/pages/teams/GameDetailPage.tsx
@@ -1,0 +1,426 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useGameStore } from '../../stores/gameStore'
+import { useAuthStore } from '../../stores/authStore'
+import { useTeamStore } from '../../stores/teamStore'
+import Spinner from '../../components/ui/Spinner'
+import type { GamePlayer, GameStats } from '../../types'
+
+// ── Computed helpers ──────────────────────────────────────────────────────────
+
+function pct(made: number, att: number): string {
+  if (att === 0) return '—'
+  return ((made / att) * 100).toFixed(1) + '%'
+}
+
+function emptyStats(): GameStats {
+  return { mins: 0, pts: 0, fgm: 0, fga: 0, three_pm: 0, three_pa: 0, ftm: 0, fta: 0, orb: 0, drb: 0, ast: 0, stl: 0, blk: 0, tov: 0, pf: 0, plus_minus: 0 }
+}
+
+// ── Box Score Table ───────────────────────────────────────────────────────────
+
+const STAT_COLS: Array<{ key: keyof GameStats; label: string }> = [
+  { key: 'mins', label: 'MINS' }, { key: 'pts', label: 'PTS' },
+  { key: 'fgm', label: 'FGM' }, { key: 'fga', label: 'FGA' },
+  { key: 'three_pm', label: '3PM' }, { key: 'three_pa', label: '3PA' },
+  { key: 'ftm', label: 'FTM' }, { key: 'fta', label: 'FTA' },
+  { key: 'orb', label: 'ORB' }, { key: 'drb', label: 'DRB' },
+  { key: 'ast', label: 'AST' }, { key: 'stl', label: 'STL' },
+  { key: 'blk', label: 'BLK' }, { key: 'tov', label: 'TOV' },
+  { key: 'pf', label: 'PF' }, { key: 'plus_minus', label: '+/-' },
+]
+
+function StatCell({
+  value,
+  onChange,
+  canEdit,
+}: {
+  value: number
+  onChange: (v: number) => void
+  canEdit: boolean
+}) {
+  const [local, setLocal] = useState(String(value))
+
+  useEffect(() => {
+    setLocal(String(value))
+  }, [value])
+
+  if (!canEdit) {
+    return <td className="px-2 py-1 text-center text-sm text-foreground/70">{value}</td>
+  }
+
+  return (
+    <td className="px-1 py-1">
+      <input
+        type="number"
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        onBlur={() => {
+          const n = parseInt(local, 10)
+          if (!isNaN(n) && n !== value) onChange(n)
+          else setLocal(String(value))
+        }}
+        className="w-14 rounded border border-secondary/20 bg-background px-1 py-0.5 text-center text-sm text-foreground focus:border-secondary focus:outline-none"
+      />
+    </td>
+  )
+}
+
+function BoxScoreTable({
+  players,
+  canEdit,
+  onSaveStats,
+  onToggleDNP,
+}: {
+  players: GamePlayer[]
+  canEdit: boolean
+  onSaveStats: (userID: string, stats: GameStats) => Promise<void>
+  onToggleDNP: (userID: string) => Promise<void>
+}) {
+  function handleStatChange(player: GamePlayer, key: keyof GameStats, val: number) {
+    const current = player.stats ?? emptyStats()
+    void onSaveStats(player.user_id, { ...current, [key]: val })
+  }
+
+  const active = players.filter((p) => !p.is_dnp)
+  const dnp = players.filter((p) => p.is_dnp)
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-secondary/20">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="border-b border-secondary/20 bg-primary">
+            <th className="sticky left-0 z-10 bg-primary px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[140px]">Player</th>
+            {STAT_COLS.map((c) => (
+              <th key={c.key} className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">{c.label}</th>
+            ))}
+            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[48px]">REB</th>
+            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">FG%</th>
+            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">3P%</th>
+            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">FT%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {active.map((player) => {
+            const s = player.stats ?? emptyStats()
+            return (
+              <tr key={player.user_id} className="border-b border-secondary/10 hover:bg-white/5">
+                <td className="sticky left-0 z-10 bg-background px-3 py-2 min-w-[140px]">
+                  <div className="flex items-center gap-2">
+                    {player.jersey_number !== null && (
+                      <span className="text-xs text-foreground/40">#{player.jersey_number}</span>
+                    )}
+                    <span className="font-medium text-foreground">{player.name}</span>
+                    {canEdit && (
+                      <button
+                        onClick={() => void onToggleDNP(player.user_id)}
+                        className="ml-1 text-xs text-foreground/30 hover:text-foreground/60"
+                        title="Mark as DNP"
+                      >DNP</button>
+                    )}
+                  </div>
+                </td>
+                {STAT_COLS.map((c) => (
+                  <StatCell
+                    key={c.key}
+                    value={s[c.key]}
+                    canEdit={canEdit}
+                    onChange={(v) => handleStatChange(player, c.key, v)}
+                  />
+                ))}
+                <td className="px-2 py-1 text-center text-sm text-accent">{s.orb + s.drb}</td>
+                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.fgm, s.fga)}</td>
+                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.three_pm, s.three_pa)}</td>
+                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.ftm, s.fta)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {dnp.length > 0 && (
+        <div className="border-t border-secondary/10 px-3 py-2">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-foreground/30">DNP</p>
+          <div className="flex flex-wrap gap-3">
+            {dnp.map((p) => (
+              <div key={p.user_id} className="flex items-center gap-1 text-sm text-foreground/40">
+                {p.jersey_number !== null && <span className="text-xs">#{p.jersey_number}</span>}
+                <span>{p.name}</span>
+                {canEdit && (
+                  <button
+                    onClick={() => void onToggleDNP(p.user_id)}
+                    className="ml-1 text-xs text-secondary hover:underline"
+                  >
+                    Mark active
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Live Mode ─────────────────────────────────────────────────────────────────
+
+type LivePanelStat =
+  | { type: 'pts2' } | { type: 'pts3' } | { type: 'ftMade' } | { type: 'ftMiss' }
+  | { type: 'fgMade' } | { type: 'fgMiss' }
+  | { type: 'orbReb' } | { type: 'drbReb' }
+  | { type: 'ast' } | { type: 'stl' } | { type: 'blk' } | { type: 'tov' } | { type: 'foul' }
+
+function applyLiveStat(current: GameStats, action: LivePanelStat): GameStats {
+  const s = { ...current }
+  switch (action.type) {
+    case 'pts2':  s.pts += 2; s.fgm += 1; s.fga += 1; break
+    case 'pts3':  s.pts += 3; s.fgm += 1; s.fga += 1; s.three_pm += 1; s.three_pa += 1; break
+    case 'ftMade': s.pts += 1; s.ftm += 1; s.fta += 1; break
+    case 'ftMiss': s.fta += 1; break
+    case 'fgMade': s.fgm += 1; s.fga += 1; break
+    case 'fgMiss': s.fga += 1; break
+    case 'orbReb': s.orb += 1; break
+    case 'drbReb': s.drb += 1; break
+    case 'ast':  s.ast += 1; break
+    case 'stl':  s.stl += 1; break
+    case 'blk':  s.blk += 1; break
+    case 'tov':  s.tov += 1; break
+    case 'foul': s.pf += 1; break
+  }
+  return s
+}
+
+function LivePanel({
+  player,
+  onAction,
+  onClose,
+}: {
+  player: GamePlayer
+  onAction: (action: LivePanelStat) => void
+  onClose: () => void
+}) {
+  const s = player.stats ?? emptyStats()
+  const btnBase = 'rounded-lg py-3 text-sm font-semibold transition-colors active:scale-95'
+  const scoring = 'bg-secondary/20 text-accent hover:bg-secondary/30'
+  const other = 'bg-white/5 text-foreground/70 hover:bg-white/10'
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-end bg-black/50" onClick={onClose}>
+      <div
+        className="w-full rounded-t-2xl border-t border-secondary/20 bg-primary p-4 pb-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <span className="text-base font-bold text-foreground">{player.name}</span>
+            {player.jersey_number !== null && (
+              <span className="ml-2 text-sm text-foreground/40">#{player.jersey_number}</span>
+            )}
+          </div>
+          <span className="text-sm text-foreground/50">{s.pts} PTS · {s.orb + s.drb} REB · {s.ast} AST</span>
+          <button onClick={onClose} className="text-foreground/40 hover:text-foreground">✕</button>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2">
+          <button className={`${btnBase} ${scoring} col-span-1`} onClick={() => onAction({ type: 'pts2' })}>+2 PT</button>
+          <button className={`${btnBase} ${scoring} col-span-1`} onClick={() => onAction({ type: 'pts3' })}>+3 PT</button>
+          <button className={`${btnBase} ${scoring} col-span-1`} onClick={() => onAction({ type: 'ftMade' })}>FT ✓</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'ftMiss' })}>FT ✗</button>
+
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'fgMade' })}>FG ✓</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'fgMiss' })}>FG ✗</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'orbReb' })}>ORB</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'drbReb' })}>DRB</button>
+
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'ast' })}>AST</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'stl' })}>STL</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'blk' })}>BLK</button>
+          <button className={`${btnBase} ${other} col-span-1`} onClick={() => onAction({ type: 'tov' })}>TOV</button>
+
+          <button className={`${btnBase} ${other} col-span-2`} onClick={() => onAction({ type: 'foul' })}>Foul (+1 PF)</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LiveMode({
+  players,
+  onAction,
+  onToggleDNP,
+}: {
+  players: GamePlayer[]
+  onAction: (userID: string, action: LivePanelStat) => void
+  onToggleDNP: (userID: string) => Promise<void>
+}) {
+  const [activePlayer, setActivePlayer] = useState<GamePlayer | null>(null)
+  const active = players.filter((p) => !p.is_dnp)
+  const dnp = players.filter((p) => p.is_dnp)
+
+  return (
+    <div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+        {active.map((player) => {
+          const s = player.stats ?? emptyStats()
+          return (
+            <button
+              key={player.user_id}
+              onClick={() => setActivePlayer(player)}
+              className="flex flex-col gap-1 rounded-xl border border-secondary/20 bg-primary p-4 text-left transition-colors hover:border-secondary/40"
+            >
+              <div className="flex items-center gap-2">
+                {player.jersey_number !== null && (
+                  <span className="text-xs text-foreground/40">#{player.jersey_number}</span>
+                )}
+                <span className="text-sm font-semibold text-foreground truncate">{player.name}</span>
+              </div>
+              <div className="flex gap-3 text-xs text-foreground/50">
+                <span><span className="font-bold text-accent">{s.pts}</span> PTS</span>
+                <span><span className="font-bold text-foreground/70">{s.orb + s.drb}</span> REB</span>
+                <span><span className="font-bold text-foreground/70">{s.ast}</span> AST</span>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {dnp.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground/30">DNP</p>
+          <div className="flex flex-wrap gap-2">
+            {dnp.map((p) => (
+              <button
+                key={p.user_id}
+                onClick={() => void onToggleDNP(p.user_id)}
+                className="rounded-lg border border-secondary/10 bg-primary px-3 py-2 text-xs text-foreground/40 hover:border-secondary/30 hover:text-foreground/60"
+              >
+                {p.name} — tap to activate
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {activePlayer && (
+        <LivePanel
+          player={activePlayer}
+          onAction={(action) => {
+            onAction(activePlayer.user_id, action)
+          }}
+          onClose={() => setActivePlayer(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function GameDetailPage() {
+  const { gameID } = useParams<{ gameID: string }>()
+  const navigate = useNavigate()
+  const { currentGame, isLoading, fetchGameDetail, updateGame, upsertStats, toggleDNP } = useGameStore()
+  const { currentTeam } = useTeamStore()
+  const { user } = useAuthStore()
+  const [mode, setMode] = useState<'boxscore' | 'live'>('boxscore')
+
+  useEffect(() => {
+    if (gameID) void fetchGameDetail(gameID)
+  }, [gameID, fetchGameDetail])
+
+  const isCoach = !!(currentTeam && user && currentTeam.coach_id === user.id)
+
+  const handleSaveStats = useCallback(async (userID: string, stats: GameStats) => {
+    if (!gameID) return
+    await upsertStats(gameID, userID, stats)
+  }, [gameID, upsertStats])
+
+  const handleToggleDNP = useCallback(async (userID: string) => {
+    if (!gameID) return
+    await toggleDNP(gameID, userID)
+  }, [gameID, toggleDNP])
+
+  const handleLiveAction = useCallback(async (userID: string, action: LivePanelStat) => {
+    if (!gameID || !currentGame) return
+    const player = currentGame.players.find((p) => p.user_id === userID)
+    if (!player) return
+    const updated = applyLiveStat(player.stats ?? emptyStats(), action)
+    await upsertStats(gameID, userID, updated)
+  }, [gameID, currentGame, upsertStats])
+
+  if (isLoading || !currentGame) {
+    return <div className="flex justify-center py-24"><Spinner size="lg" /></div>
+  }
+
+  const { game, players } = currentGame
+  const teamScore = players.filter((p) => !p.is_dnp).reduce((sum, p) => sum + (p.stats?.pts ?? 0), 0)
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <button onClick={() => navigate(`/teams/${game.team_id}`)} className="text-sm text-foreground/40 hover:text-foreground">
+            ← Back
+          </button>
+          <h1 className="mt-1 text-xl font-bold text-foreground">vs {game.opponent_name}</h1>
+          <p className="text-sm text-foreground/50">{game.game_date}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-3xl font-bold text-foreground tabular-nums">
+            {game.team_score ?? teamScore} — {game.opponent_score ?? '?'}
+          </p>
+          {isCoach && (
+            <div className="mt-1 flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  const opp = window.prompt('Opponent score:', String(game.opponent_score ?? ''))
+                  if (opp === null) return
+                  const n = parseInt(opp, 10)
+                  if (!isNaN(n)) void updateGame(game.id, { opponent_score: n })
+                }}
+                className="text-xs text-foreground/40 hover:text-foreground"
+              >
+                Set opp. score
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Mode toggle */}
+      {isCoach && (
+        <div className="flex gap-1 self-start rounded-lg border border-secondary/20 bg-primary p-1">
+          {(['boxscore', 'live'] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              className={`rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                mode === m ? 'bg-secondary text-background' : 'text-foreground/50 hover:text-foreground'
+              }`}
+            >
+              {m === 'boxscore' ? 'Box Score' : 'Live Track'}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Content */}
+      {mode === 'boxscore' ? (
+        <BoxScoreTable
+          players={players}
+          canEdit={isCoach}
+          onSaveStats={handleSaveStats}
+          onToggleDNP={handleToggleDNP}
+        />
+      ) : (
+        <LiveMode
+          players={players}
+          onAction={handleLiveAction}
+          onToggleDNP={handleToggleDNP}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/teams/GameDetailPage.tsx
+++ b/frontend/src/pages/teams/GameDetailPage.tsx
@@ -46,11 +46,11 @@ function StatCell({
   }, [value])
 
   if (!canEdit) {
-    return <td className="px-2 py-1 text-center text-sm text-foreground/70">{value}</td>
+    return <td className="px-0.5 py-1 text-center text-xs text-foreground/70 min-w-[38px]">{value}</td>
   }
 
   return (
-    <td className="px-1 py-1">
+    <td className="px-0.5 py-1 min-w-[38px]">
       <input
         type="number"
         value={local}
@@ -60,7 +60,7 @@ function StatCell({
           if (!isNaN(n) && n !== value) onChange(n)
           else setLocal(String(value))
         }}
-        className="w-14 rounded border border-secondary/20 bg-background px-1 py-0.5 text-center text-sm text-foreground focus:border-secondary focus:outline-none"
+        className="w-9 rounded border border-secondary/20 bg-background px-0.5 py-0.5 text-center text-xs text-foreground focus:border-secondary focus:outline-none"
       />
     </td>
   )
@@ -87,17 +87,17 @@ function BoxScoreTable({
 
   return (
     <div className="overflow-x-auto rounded-lg border border-secondary/20">
-      <table className="min-w-full text-sm">
+      <table className="min-w-full">
         <thead>
           <tr className="border-b border-secondary/20 bg-primary">
-            <th className="sticky left-0 z-10 bg-primary px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[140px]">Player</th>
+            <th className="sticky left-0 z-10 bg-primary px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[120px]">Player</th>
             {STAT_COLS.map((c) => (
-              <th key={c.key} className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">{c.label}</th>
+              <th key={c.key} className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">{c.label}</th>
             ))}
-            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[48px]">REB</th>
-            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">FG%</th>
-            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">3P%</th>
-            <th className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[56px]">FT%</th>
+            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">REB</th>
+            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">FG%</th>
+            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">3P%</th>
+            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">FT%</th>
           </tr>
         </thead>
         <tbody>
@@ -105,16 +105,16 @@ function BoxScoreTable({
             const s = player.stats ?? emptyStats()
             return (
               <tr key={player.user_id} className="border-b border-secondary/10 hover:bg-white/5">
-                <td className="sticky left-0 z-10 bg-background px-3 py-2 min-w-[140px]">
-                  <div className="flex items-center gap-2">
+                <td className="sticky left-0 z-10 bg-background px-3 py-2 min-w-[120px]">
+                  <div className="flex items-center gap-1.5">
                     {player.jersey_number !== null && (
                       <span className="text-xs text-foreground/40">#{player.jersey_number}</span>
                     )}
-                    <span className="font-medium text-foreground">{player.name}</span>
+                    <span className="text-xs font-medium text-foreground">{player.name}</span>
                     {canEdit && (
                       <button
                         onClick={() => void onToggleDNP(player.user_id)}
-                        className="ml-1 text-xs text-foreground/30 hover:text-foreground/60"
+                        className="text-xs text-foreground/30 hover:text-foreground/60"
                         title="Mark as DNP"
                       >DNP</button>
                     )}
@@ -128,10 +128,10 @@ function BoxScoreTable({
                     onChange={(v) => handleStatChange(player, c.key, v)}
                   />
                 ))}
-                <td className="px-2 py-1 text-center text-sm text-accent">{s.orb + s.drb}</td>
-                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.fgm, s.fga)}</td>
-                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.three_pm, s.three_pa)}</td>
-                <td className="px-2 py-1 text-center text-sm text-foreground/50">{pct(s.ftm, s.fta)}</td>
+                <td className="px-0.5 py-1 text-center text-xs text-accent min-w-[38px]">{s.orb + s.drb}</td>
+                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.fgm, s.fga)}</td>
+                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.three_pm, s.three_pa)}</td>
+                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.ftm, s.fta)}</td>
               </tr>
             )
           })}

--- a/frontend/src/pages/teams/GameDetailPage.tsx
+++ b/frontend/src/pages/teams/GameDetailPage.tsx
@@ -19,15 +19,32 @@ function emptyStats(): GameStats {
 
 // ── Box Score Table ───────────────────────────────────────────────────────────
 
-const STAT_COLS: Array<{ key: keyof GameStats; label: string }> = [
-  { key: 'mins', label: 'MINS' }, { key: 'pts', label: 'PTS' },
-  { key: 'fgm', label: 'FGM' }, { key: 'fga', label: 'FGA' },
-  { key: 'three_pm', label: '3PM' }, { key: 'three_pa', label: '3PA' },
-  { key: 'ftm', label: 'FTM' }, { key: 'fta', label: 'FTA' },
-  { key: 'orb', label: 'ORB' }, { key: 'drb', label: 'DRB' },
-  { key: 'ast', label: 'AST' }, { key: 'stl', label: 'STL' },
-  { key: 'blk', label: 'BLK' }, { key: 'tov', label: 'TOV' },
-  { key: 'pf', label: 'PF' }, { key: 'plus_minus', label: '+/-' },
+// Columns with computed stats interleaved where they belong.
+type ColDef =
+  | { kind: 'raw'; key: keyof GameStats; label: string }
+  | { kind: 'computed'; label: string; render: (s: GameStats) => string | number }
+
+const STAT_COLS: ColDef[] = [
+  { kind: 'raw', key: 'mins', label: 'MIN' },
+  { kind: 'raw', key: 'pts', label: 'PTS' },
+  { kind: 'raw', key: 'fgm', label: 'FGM' },
+  { kind: 'raw', key: 'fga', label: 'FGA' },
+  { kind: 'computed', label: 'FG%', render: (s) => pct(s.fgm, s.fga) },
+  { kind: 'raw', key: 'three_pm', label: '3PM' },
+  { kind: 'raw', key: 'three_pa', label: '3PA' },
+  { kind: 'computed', label: '3P%', render: (s) => pct(s.three_pm, s.three_pa) },
+  { kind: 'raw', key: 'ftm', label: 'FTM' },
+  { kind: 'raw', key: 'fta', label: 'FTA' },
+  { kind: 'computed', label: 'FT%', render: (s) => pct(s.ftm, s.fta) },
+  { kind: 'raw', key: 'orb', label: 'ORB' },
+  { kind: 'raw', key: 'drb', label: 'DRB' },
+  { kind: 'computed', label: 'REB', render: (s) => s.orb + s.drb },
+  { kind: 'raw', key: 'ast', label: 'AST' },
+  { kind: 'raw', key: 'stl', label: 'STL' },
+  { kind: 'raw', key: 'blk', label: 'BLK' },
+  { kind: 'raw', key: 'tov', label: 'TOV' },
+  { kind: 'raw', key: 'pf', label: 'PF' },
+  { kind: 'raw', key: 'plus_minus', label: '+/-' },
 ]
 
 function StatCell({
@@ -74,12 +91,12 @@ function BoxScoreTable({
 }: {
   players: GamePlayer[]
   canEdit: boolean
-  onSaveStats: (userID: string, stats: GameStats) => Promise<void>
-  onToggleDNP: (userID: string) => Promise<void>
+  onSaveStats: (memberID: string, stats: GameStats) => Promise<void>
+  onToggleDNP: (memberID: string) => Promise<void>
 }) {
   function handleStatChange(player: GamePlayer, key: keyof GameStats, val: number) {
     const current = player.stats ?? emptyStats()
-    void onSaveStats(player.user_id, { ...current, [key]: val })
+    void onSaveStats(player.member_id, { ...current, [key]: val })
   }
 
   const active = players.filter((p) => !p.is_dnp)
@@ -91,20 +108,16 @@ function BoxScoreTable({
         <thead>
           <tr className="border-b border-secondary/20 bg-primary">
             <th className="sticky left-0 z-10 bg-primary px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[120px]">Player</th>
-            {STAT_COLS.map((c) => (
-              <th key={c.key} className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">{c.label}</th>
+            {STAT_COLS.map((c, i) => (
+              <th key={i} className={`px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide min-w-[38px] ${c.kind === 'computed' ? 'text-foreground/30' : 'text-foreground/50'}`}>{c.label}</th>
             ))}
-            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">REB</th>
-            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">FG%</th>
-            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">3P%</th>
-            <th className="px-0.5 py-2 text-center text-xs font-semibold uppercase tracking-wide text-foreground/50 min-w-[38px]">FT%</th>
           </tr>
         </thead>
         <tbody>
           {active.map((player) => {
             const s = player.stats ?? emptyStats()
             return (
-              <tr key={player.user_id} className="border-b border-secondary/10 hover:bg-white/5">
+              <tr key={player.member_id} className="border-b border-secondary/10 hover:bg-white/5">
                 <td className="sticky left-0 z-10 bg-background px-3 py-2 min-w-[120px]">
                   <div className="flex items-center gap-1.5">
                     {player.jersey_number !== null && (
@@ -113,25 +126,25 @@ function BoxScoreTable({
                     <span className="text-xs font-medium text-foreground">{player.name}</span>
                     {canEdit && (
                       <button
-                        onClick={() => void onToggleDNP(player.user_id)}
+                        onClick={() => void onToggleDNP(player.member_id)}
                         className="text-xs text-foreground/30 hover:text-foreground/60"
                         title="Mark as DNP"
                       >DNP</button>
                     )}
                   </div>
                 </td>
-                {STAT_COLS.map((c) => (
-                  <StatCell
-                    key={c.key}
-                    value={s[c.key]}
-                    canEdit={canEdit}
-                    onChange={(v) => handleStatChange(player, c.key, v)}
-                  />
-                ))}
-                <td className="px-0.5 py-1 text-center text-xs text-accent min-w-[38px]">{s.orb + s.drb}</td>
-                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.fgm, s.fga)}</td>
-                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.three_pm, s.three_pa)}</td>
-                <td className="px-0.5 py-1 text-center text-xs text-foreground/50 min-w-[38px]">{pct(s.ftm, s.fta)}</td>
+                {STAT_COLS.map((c, i) =>
+                  c.kind === 'raw' ? (
+                    <StatCell
+                      key={i}
+                      value={s[c.key]}
+                      canEdit={canEdit}
+                      onChange={(v) => handleStatChange(player, c.key, v)}
+                    />
+                  ) : (
+                    <td key={i} className="px-0.5 py-1 text-center text-xs text-foreground/40 min-w-[38px]">{c.render(s)}</td>
+                  )
+                )}
               </tr>
             )
           })}
@@ -143,12 +156,12 @@ function BoxScoreTable({
           <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-foreground/30">DNP</p>
           <div className="flex flex-wrap gap-3">
             {dnp.map((p) => (
-              <div key={p.user_id} className="flex items-center gap-1 text-sm text-foreground/40">
+              <div key={p.member_id} className="flex items-center gap-1 text-sm text-foreground/40">
                 {p.jersey_number !== null && <span className="text-xs">#{p.jersey_number}</span>}
                 <span>{p.name}</span>
                 {canEdit && (
                   <button
-                    onClick={() => void onToggleDNP(p.user_id)}
+                    onClick={() => void onToggleDNP(p.member_id)}
                     className="ml-1 text-xs text-secondary hover:underline"
                   >
                     Mark active
@@ -254,14 +267,14 @@ function LiveMode({
   onToggleDNP,
 }: {
   players: GamePlayer[]
-  onAction: (userID: string, action: LivePanelStat) => void
-  onToggleDNP: (userID: string) => Promise<void>
+  onAction: (memberID: string, action: LivePanelStat) => void
+  onToggleDNP: (memberID: string) => Promise<void>
 }) {
   const [activePlayerID, setActivePlayerID] = useState<string | null>(null)
   const active = players.filter((p) => !p.is_dnp)
   const dnp = players.filter((p) => p.is_dnp)
   // Derive from props so the panel always shows the latest stats from the store
-  const activePlayer = activePlayerID ? (players.find((p) => p.user_id === activePlayerID) ?? null) : null
+  const activePlayer = activePlayerID ? (players.find((p) => p.member_id === activePlayerID) ?? null) : null
 
   return (
     <div>
@@ -270,8 +283,8 @@ function LiveMode({
           const s = player.stats ?? emptyStats()
           return (
             <button
-              key={player.user_id}
-              onClick={() => setActivePlayerID(player.user_id)}
+              key={player.member_id}
+              onClick={() => setActivePlayerID(player.member_id)}
               className="flex flex-col gap-1 rounded-xl border border-secondary/20 bg-primary p-4 text-left transition-colors hover:border-secondary/40"
             >
               <div className="flex items-center gap-2">
@@ -296,8 +309,8 @@ function LiveMode({
           <div className="flex flex-wrap gap-2">
             {dnp.map((p) => (
               <button
-                key={p.user_id}
-                onClick={() => void onToggleDNP(p.user_id)}
+                key={p.member_id}
+                onClick={() => void onToggleDNP(p.member_id)}
                 className="rounded-lg border border-secondary/10 bg-primary px-3 py-2 text-xs text-foreground/40 hover:border-secondary/30 hover:text-foreground/60"
               >
                 {p.name} — tap to activate
@@ -311,7 +324,7 @@ function LiveMode({
         <LivePanel
           player={activePlayer}
           onAction={(action) => {
-            onAction(activePlayer.user_id, action)
+            onAction(activePlayer.member_id, action)
           }}
           onClose={() => setActivePlayerID(null)}
         />
@@ -336,22 +349,22 @@ export default function GameDetailPage() {
 
   const isCoach = !!(currentTeam && user && currentTeam.coach_id === user.id)
 
-  const handleSaveStats = useCallback(async (userID: string, stats: GameStats) => {
+  const handleSaveStats = useCallback(async (memberID: string, stats: GameStats) => {
     if (!gameID) return
-    await upsertStats(gameID, userID, stats)
+    await upsertStats(gameID, memberID, stats)
   }, [gameID, upsertStats])
 
-  const handleToggleDNP = useCallback(async (userID: string) => {
+  const handleToggleDNP = useCallback(async (memberID: string) => {
     if (!gameID) return
-    await toggleDNP(gameID, userID)
+    await toggleDNP(gameID, memberID)
   }, [gameID, toggleDNP])
 
-  const handleLiveAction = useCallback(async (userID: string, action: LivePanelStat) => {
+  const handleLiveAction = useCallback(async (memberID: string, action: LivePanelStat) => {
     if (!gameID || !currentGame) return
-    const player = currentGame.players.find((p) => p.user_id === userID)
+    const player = currentGame.players.find((p) => p.member_id === memberID)
     if (!player) return
     const updated = applyLiveStat(player.stats ?? emptyStats(), action)
-    await upsertStats(gameID, userID, updated)
+    await upsertStats(gameID, memberID, updated)
   }, [gameID, currentGame, upsertStats])
 
   if (isLoading || !currentGame) {

--- a/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -19,55 +19,204 @@ function RoleBadge({ role }: { role: 'coach' | 'player' }) {
   return <Badge variant={role === 'coach' ? 'blue' : 'gray'}>{role === 'coach' ? 'Coach' : 'Player'}</Badge>
 }
 
+// ─── Add Roster Member Form ───────────────────────────────────────────────────
+
+function AddRosterForm({ teamID, onDone }: { teamID: string; onDone: () => void }) {
+  const { addRosterMember } = useTeamStore()
+  const [name, setName] = useState('')
+  const [jersey, setJersey] = useState('')
+  const [position, setPosition] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) return
+    setIsLoading(true)
+    setError('')
+    try {
+      await addRosterMember(teamID, {
+        name: name.trim(),
+        jersey_number: jersey ? parseInt(jersey, 10) : null,
+        position: position.trim() || null,
+      })
+      setName('')
+      setJersey('')
+      setPosition('')
+      onDone()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to add player.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 flex flex-col gap-3 rounded-lg border border-secondary/20 bg-primary p-4">
+      <p className="text-sm font-medium text-foreground/70">Add player to roster</p>
+      <div className="flex gap-2">
+        <Input
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Player name"
+          className="flex-1"
+          disabled={isLoading}
+        />
+        <Input
+          label="Jersey #"
+          type="number"
+          value={jersey}
+          onChange={(e) => setJersey(e.target.value)}
+          placeholder="23"
+          className="w-24"
+          disabled={isLoading}
+        />
+        <Input
+          label="Position"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          placeholder="PG"
+          className="w-24"
+          disabled={isLoading}
+        />
+      </div>
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <Button variant="secondary" type="button" onClick={onDone}>Cancel</Button>
+        <Button type="submit" isLoading={isLoading}>Add Player</Button>
+      </div>
+    </form>
+  )
+}
+
+// ─── Inline Invite Form (for placeholder slots) ───────────────────────────────
+
+function SlotInviteForm({ teamID, memberID, onDone }: { teamID: string; memberID: string; onDone: () => void }) {
+  const { inviteMember } = useTeamStore()
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!email.trim() || status === 'loading') return
+    setStatus('loading')
+    setMessage('')
+    try {
+      await inviteMember(teamID, email.trim(), memberID)
+      setStatus('success')
+      setMessage(`Invite sent to ${email.trim()}.`)
+    } catch (err) {
+      setStatus('error')
+      setMessage(err instanceof ApiError ? err.message : 'Failed to send invite.')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="mt-2 flex items-center gap-2">
+        <p className="text-xs text-accent">{message}</p>
+        <button onClick={onDone} className="text-xs text-foreground/40 hover:text-foreground">Done</button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="mt-2 flex gap-2">
+      <Input
+        label=""
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="player@example.com"
+        className="flex-1"
+        disabled={status === 'loading'}
+      />
+      <Button type="submit" isLoading={status === 'loading'} className="self-end">Send</Button>
+      <Button variant="secondary" type="button" onClick={onDone} className="self-end">Cancel</Button>
+      {status === 'error' && <p className="text-xs text-red-400">{message}</p>}
+    </form>
+  )
+}
+
+// ─── Member Row ───────────────────────────────────────────────────────────────
+
 function MemberRow({
   mwu,
+  teamID,
   isCoach,
   isCurrentUser,
   onRemove,
 }: {
   mwu: MemberWithUser
+  teamID: string
   isCoach: boolean
   isCurrentUser: boolean
   onRemove: () => void
 }) {
   const { member, user } = mwu
   const canRemove = isCoach && member.role !== 'coach'
+  const isPlaceholder = user === null
+  const displayName = isPlaceholder ? (member.name ?? 'Unnamed') : user.name
+  const [showInvite, setShowInvite] = useState(false)
 
   return (
-    <div className="flex items-center gap-4 border-b border-secondary/10 py-3 last:border-0">
-      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-secondary/20 text-sm font-semibold text-accent">
-        {user.name.charAt(0).toUpperCase()}
+    <div className="border-b border-secondary/10 py-3 last:border-0">
+      <div className="flex items-center gap-4">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-secondary/20 text-sm font-semibold text-accent">
+          {displayName.charAt(0).toUpperCase()}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">
+            {displayName}
+            {isCurrentUser && <span className="ml-1 text-xs text-foreground/30">(you)</span>}
+          </p>
+          {isPlaceholder ? (
+            <p className="text-xs text-foreground/30 italic">No account yet</p>
+          ) : (
+            <p className="truncate text-xs text-foreground/40">{user.email}</p>
+          )}
+        </div>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          {member.jersey_number !== null && (
+            <span className="text-xs text-foreground/40">#{member.jersey_number}</span>
+          )}
+          {member.position && (
+            <span className="text-xs text-foreground/40">{member.position}</span>
+          )}
+          <RoleBadge role={member.role} />
+          {isCoach && isPlaceholder && !showInvite && (
+            <button
+              onClick={() => setShowInvite(true)}
+              className="rounded px-2 py-1 text-xs text-accent border border-secondary/30 hover:bg-secondary/10"
+            >
+              Invite
+            </button>
+          )}
+          {canRemove && (
+            <button
+              onClick={onRemove}
+              className="rounded p-1 text-foreground/30 hover:bg-red-900/30 hover:text-red-400"
+              aria-label={`Remove ${displayName}`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">
-          {user.name}
-          {isCurrentUser && <span className="ml-1 text-xs text-foreground/30">(you)</span>}
-        </p>
-        <p className="truncate text-xs text-foreground/40">{user.email}</p>
-      </div>
-      <div className="flex flex-shrink-0 items-center gap-2">
-        {member.jersey_number !== null && (
-          <span className="text-xs text-foreground/40">#{member.jersey_number}</span>
-        )}
-        {member.position && (
-          <span className="text-xs text-foreground/40">{member.position}</span>
-        )}
-        <RoleBadge role={member.role} />
-        {canRemove && (
-          <button
-            onClick={onRemove}
-            className="rounded p-1 text-foreground/30 hover:bg-red-900/30 hover:text-red-400"
-            aria-label={`Remove ${user.name}`}
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
-      </div>
+      {showInvite && (
+        <div className="mt-2 pl-13">
+          <SlotInviteForm teamID={teamID} memberID={member.id} onDone={() => setShowInvite(false)} />
+        </div>
+      )}
     </div>
   )
 }
+
+// ─── General Invite Form ──────────────────────────────────────────────────────
 
 function InviteForm({ teamID }: { teamID: string }) {
   const { inviteMember } = useTeamStore()
@@ -93,7 +242,7 @@ function InviteForm({ teamID }: { teamID: string }) {
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 flex flex-col gap-3 rounded-lg border border-secondary/20 bg-primary p-4">
-      <p className="text-sm font-medium text-foreground/70">Invite a player</p>
+      <p className="text-sm font-medium text-foreground/70">Invite by email</p>
       <div className="flex gap-2">
         <Input
           label=""
@@ -475,6 +624,7 @@ export default function TeamDetailPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [showEditModal, setShowEditModal] = useState(false)
   const [removeError, setRemoveError] = useState<string | null>(null)
+  const [showAddRoster, setShowAddRoster] = useState(false)
 
   useEffect(() => {
     if (!teamID) return
@@ -497,8 +647,8 @@ export default function TeamDetailPage() {
     }
   }
 
-  async function handleRemoveMember(userID: string, userName: string) {
-    if (!teamID || !window.confirm(`Remove ${userName} from this team?`)) return
+  async function handleRemoveMember(userID: string, displayName: string) {
+    if (!teamID || !window.confirm(`Remove ${displayName} from this team?`)) return
     setRemoveError(null)
     try {
       await removeMember(teamID, userID)
@@ -582,25 +732,39 @@ export default function TeamDetailPage() {
                     {removeError}
                   </p>
                 )}
+                <div className="mb-4 flex items-center justify-between">
+                  <p className="text-sm text-foreground/50">{members.length} member{members.length !== 1 ? 's' : ''}</p>
+                  {isCoach && (
+                    <Button onClick={() => setShowAddRoster((v) => !v)}>Add Player</Button>
+                  )}
+                </div>
                 <div className="rounded-lg border border-secondary/20 bg-primary px-4">
                   {members.length === 0 ? (
                     <p className="py-8 text-center text-sm text-foreground/40">
                       No members yet.
-                      {isCoach && <span className="block mt-1 text-xs text-foreground/30">Use "Invite a player" below to add members.</span>}
+                      {isCoach && <span className="block mt-1 text-xs text-foreground/30">Use "Add Player" to add roster slots.</span>}
                     </p>
                   ) : (
                     members.map((mwu) => (
                       <MemberRow
                         key={mwu.member.id}
                         mwu={mwu}
+                        teamID={teamID!}
                         isCoach={isCoach}
-                        isCurrentUser={mwu.user.id === user?.id}
-                        onRemove={() => void handleRemoveMember(mwu.user.id, mwu.user.name)}
+                        isCurrentUser={mwu.user?.id === user?.id}
+                        onRemove={() => {
+                          const id = mwu.user?.id
+                          const name = mwu.user?.name ?? mwu.member.name ?? 'player'
+                          if (id) void handleRemoveMember(id, name)
+                        }}
                       />
                     ))
                   )}
                 </div>
               </>
+            )}
+            {isCoach && teamID && showAddRoster && (
+              <AddRosterForm teamID={teamID} onDone={() => setShowAddRoster(false)} />
             )}
             {isCoach && teamID && <InviteForm teamID={teamID} />}
           </div>

--- a/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useTeamStore } from '../../stores/teamStore'
 import { useAuthStore } from '../../stores/authStore'
 import { usePlaybookStore } from '../../stores/playbookStore'
+import { useGameStore } from '../../stores/gameStore'
 import { teamsApi } from '../../api/teams'
 import Button from '../../components/ui/Button'
 import Badge from '../../components/ui/Badge'
@@ -10,9 +11,9 @@ import Spinner from '../../components/ui/Spinner'
 import Input from '../../components/ui/Input'
 import Modal from '../../components/ui/Modal'
 import { ApiError } from '../../api/client'
-import type { MemberWithUser, Playbook } from '../../types'
+import type { MemberWithUser, Playbook, Game } from '../../types'
 
-type Tab = 'roster' | 'playbooks'
+type Tab = 'roster' | 'playbooks' | 'games'
 
 function RoleBadge({ role }: { role: 'coach' | 'player' }) {
   return <Badge variant={role === 'coach' ? 'blue' : 'gray'}>{role === 'coach' ? 'Coach' : 'Player'}</Badge>
@@ -343,6 +344,125 @@ function PlaybooksTab({ teamID, isCoach }: { teamID: string; isCoach: boolean })
   )
 }
 
+// ─── Games tab ────────────────────────────────────────────────────────────────
+
+function GamesTab({ teamID, isCoach }: { teamID: string; isCoach: boolean }) {
+  const navigate = useNavigate()
+  const { games, isLoading, fetchGames, createGame, deleteGame } = useGameStore()
+  const [showCreate, setShowCreate] = useState(false)
+  const [opponentName, setOpponentName] = useState('')
+  const [gameDate, setGameDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState('')
+
+  useEffect(() => {
+    void fetchGames(teamID)
+  }, [teamID, fetchGames])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!opponentName.trim()) return
+    setCreating(true)
+    setCreateError('')
+    try {
+      const game = await createGame(teamID, { opponent_name: opponentName.trim(), game_date: gameDate })
+      navigate(`/games/${game.id}`)
+    } catch {
+      setCreateError('Failed to create game.')
+      setCreating(false)
+    }
+  }
+
+  function gameResult(g: Game): string {
+    if (g.team_score === null || g.opponent_score === null) return '—'
+    if (g.team_score > g.opponent_score) return 'W'
+    if (g.team_score < g.opponent_score) return 'L'
+    return 'T'
+  }
+
+  if (isLoading) {
+    return <div className="flex justify-center py-12"><Spinner size="lg" /></div>
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-sm text-foreground/50">{games.length} game{games.length !== 1 ? 's' : ''}</p>
+        {isCoach && <Button onClick={() => setShowCreate((v) => !v)}>Log Game</Button>}
+      </div>
+
+      {showCreate && isCoach && (
+        <form onSubmit={(e) => void handleCreate(e)} className="mb-4 flex flex-col gap-3 rounded-lg border border-secondary/20 bg-primary p-4">
+          <p className="text-sm font-medium text-foreground/70">New Game</p>
+          <div className="flex gap-3">
+            <Input
+              label="Opponent"
+              value={opponentName}
+              onChange={(e) => setOpponentName(e.target.value)}
+              placeholder="e.g. Lakers"
+              className="flex-1"
+            />
+            <Input
+              label="Date"
+              type="date"
+              value={gameDate}
+              onChange={(e) => setGameDate(e.target.value)}
+            />
+          </div>
+          {createError && <p className="text-sm text-red-400">{createError}</p>}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" type="button" onClick={() => setShowCreate(false)}>Cancel</Button>
+            <Button type="submit" isLoading={creating}>Create</Button>
+          </div>
+        </form>
+      )}
+
+      {games.length === 0 ? (
+        <div className="rounded-lg border border-secondary/10 bg-primary py-16 text-center">
+          <p className="text-sm text-foreground/40">No games logged yet.</p>
+          {isCoach && <p className="mt-1 text-xs text-foreground/30">Click "Log Game" to add your first game.</p>}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {games.map((g) => {
+            const result = gameResult(g)
+            const resultColor = result === 'W' ? 'text-secondary' : result === 'L' ? 'text-red-400' : 'text-foreground/40'
+            return (
+              <div
+                key={g.id}
+                onClick={() => navigate(`/games/${g.id}`)}
+                className="flex cursor-pointer items-center justify-between rounded-lg border border-secondary/20 bg-primary px-4 py-3 transition-colors hover:border-secondary/40"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-foreground">vs {g.opponent_name}</p>
+                  <p className="text-xs text-foreground/40">{g.game_date}</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <span className="text-sm tabular-nums text-foreground/70">
+                    {g.team_score ?? '—'} — {g.opponent_score ?? '—'}
+                  </span>
+                  <span className={`text-sm font-bold ${resultColor}`}>{result}</span>
+                  {isCoach && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); void deleteGame(g.id) }}
+                      className="rounded p-1 text-foreground/30 hover:bg-red-900/30 hover:text-red-400"
+                      aria-label="Delete game"
+                    >
+                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Main page ────────────────────────────────────────────────────────────────
 
 export default function TeamDetailPage() {
@@ -431,7 +551,7 @@ export default function TeamDetailPage() {
       {/* Tabs */}
       <div className="mt-6 border-b border-secondary/20">
         <nav className="-mb-px flex gap-6">
-          {(['roster', 'playbooks'] as Tab[]).map((tab) => (
+          {(['roster', 'playbooks', 'games'] as Tab[]).map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -487,6 +607,9 @@ export default function TeamDetailPage() {
         )}
         {activeTab === 'playbooks' && teamID && (
           <PlaybooksTab teamID={teamID} isCoach={isCoach} />
+        )}
+        {activeTab === 'games' && teamID && (
+          <GamesTab teamID={teamID} isCoach={isCoach} />
         )}
       </div>
 

--- a/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -140,6 +140,80 @@ function SlotInviteForm({ teamID, memberID, onDone }: { teamID: string; memberID
   )
 }
 
+// ─── Inline Edit Form ─────────────────────────────────────────────────────────
+
+function EditMemberForm({
+  teamID,
+  mwu,
+  onDone,
+}: {
+  teamID: string
+  mwu: MemberWithUser
+  onDone: () => void
+}) {
+  const { updateMember } = useTeamStore()
+  const { member, user } = mwu
+  const isPlaceholder = user === null
+  const [name, setName] = useState(member.name ?? '')
+  const [jersey, setJersey] = useState(member.jersey_number !== null ? String(member.jersey_number) : '')
+  const [position, setPosition] = useState(member.position ?? '')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setIsLoading(true)
+    setError('')
+    try {
+      await updateMember(teamID, member.id, {
+        jersey_number: jersey ? parseInt(jersey, 10) : null,
+        position: position.trim() || null,
+        name: isPlaceholder ? (name.trim() || undefined) : undefined,
+      })
+      onDone()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to update.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="mt-2 flex flex-wrap items-end gap-2">
+      {isPlaceholder && (
+        <Input
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Player name"
+          className="w-36"
+          disabled={isLoading}
+        />
+      )}
+      <Input
+        label="Jersey #"
+        type="number"
+        value={jersey}
+        onChange={(e) => setJersey(e.target.value)}
+        placeholder="23"
+        className="w-20"
+        disabled={isLoading}
+      />
+      <Input
+        label="Position"
+        value={position}
+        onChange={(e) => setPosition(e.target.value)}
+        placeholder="PG"
+        className="w-20"
+        disabled={isLoading}
+      />
+      {error && <p className="w-full text-xs text-red-400">{error}</p>}
+      <Button type="submit" isLoading={isLoading}>Save</Button>
+      <Button variant="secondary" type="button" onClick={onDone}>Cancel</Button>
+    </form>
+  )
+}
+
 // ─── Member Row ───────────────────────────────────────────────────────────────
 
 function MemberRow({
@@ -160,6 +234,7 @@ function MemberRow({
   const isPlaceholder = user === null
   const displayName = isPlaceholder ? (member.name ?? 'Unnamed') : user.name
   const [showInvite, setShowInvite] = useState(false)
+  const [showEdit, setShowEdit] = useState(false)
 
   return (
     <div className="border-b border-secondary/10 py-3 last:border-0">
@@ -186,7 +261,18 @@ function MemberRow({
             <span className="text-xs text-foreground/40">{member.position}</span>
           )}
           <RoleBadge role={member.role} />
-          {isCoach && isPlaceholder && !showInvite && (
+          {isCoach && (
+            <button
+              onClick={() => { setShowEdit((v) => !v); setShowInvite(false) }}
+              className="rounded p-1 text-foreground/30 hover:bg-secondary/10 hover:text-foreground/60"
+              aria-label={`Edit ${displayName}`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 13l-4 1 1-4L15.232 5.232a2 2 0 012.828 0l.708.708a2 2 0 010 2.828L9 13z" />
+              </svg>
+            </button>
+          )}
+          {isCoach && isPlaceholder && !showInvite && !showEdit && (
             <button
               onClick={() => setShowInvite(true)}
               className="rounded px-2 py-1 text-xs text-accent border border-secondary/30 hover:bg-secondary/10"
@@ -207,6 +293,11 @@ function MemberRow({
           )}
         </div>
       </div>
+      {showEdit && (
+        <div className="mt-2 pl-13">
+          <EditMemberForm teamID={teamID} mwu={mwu} onDone={() => setShowEdit(false)} />
+        </div>
+      )}
       {showInvite && (
         <div className="mt-2 pl-13">
           <SlotInviteForm teamID={teamID} memberID={member.id} onDone={() => setShowInvite(false)} />
@@ -647,11 +738,11 @@ export default function TeamDetailPage() {
     }
   }
 
-  async function handleRemoveMember(userID: string, displayName: string) {
+  async function handleRemoveMember(memberID: string, displayName: string) {
     if (!teamID || !window.confirm(`Remove ${displayName} from this team?`)) return
     setRemoveError(null)
     try {
-      await removeMember(teamID, userID)
+      await removeMember(teamID, memberID)
     } catch (err) {
       setRemoveError(err instanceof ApiError ? err.message : 'Failed to remove member.')
     }
@@ -753,9 +844,8 @@ export default function TeamDetailPage() {
                         isCoach={isCoach}
                         isCurrentUser={mwu.user?.id === user?.id}
                         onRemove={() => {
-                          const id = mwu.user?.id
                           const name = mwu.user?.name ?? mwu.member.name ?? 'player'
-                          if (id) void handleRemoveMember(id, name)
+                          void handleRemoveMember(mwu.member.id, name)
                         }}
                       />
                     ))

--- a/frontend/src/pages/teams/TeamDetailPage.tsx
+++ b/frontend/src/pages/teams/TeamDetailPage.tsx
@@ -684,7 +684,12 @@ function GamesTab({ teamID, isCoach }: { teamID: string; isCoach: boolean }) {
                   <span className={`text-sm font-bold ${resultColor}`}>{result}</span>
                   {isCoach && (
                     <button
-                      onClick={(e) => { e.stopPropagation(); void deleteGame(g.id) }}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (window.confirm(`Delete game vs ${g.opponent_name}? This cannot be undone.`)) {
+                          void deleteGame(g.id)
+                        }
+                      }}
                       className="rounded p-1 text-foreground/30 hover:bg-red-900/30 hover:text-red-400"
                       aria-label="Delete game"
                     >

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -62,30 +62,30 @@ export const useGameStore = create<GameState>((set) => ({
     }))
   },
 
-  async upsertStats(gameID: string, userID: string, stats: GameStats) {
-    const updated = await gamesApi.upsertStats(gameID, userID, stats)
+  async upsertStats(gameID: string, memberID: string, stats: GameStats) {
+    const updated = await gamesApi.upsertStats(gameID, memberID, stats)
     set((s) => {
       if (!s.currentGame) return {}
       return {
         currentGame: {
           ...s.currentGame,
           players: s.currentGame.players.map((p: GamePlayer) =>
-            p.user_id === userID ? { ...p, stats: updated } : p,
+            p.member_id === memberID ? { ...p, stats: updated } : p,
           ),
         },
       }
     })
   },
 
-  async toggleDNP(gameID: string, userID: string) {
-    const { is_dnp } = await gamesApi.toggleDNP(gameID, userID)
+  async toggleDNP(gameID: string, memberID: string) {
+    const { is_dnp } = await gamesApi.toggleDNP(gameID, memberID)
     set((s) => {
       if (!s.currentGame) return {}
       return {
         currentGame: {
           ...s.currentGame,
           players: s.currentGame.players.map((p: GamePlayer) =>
-            p.user_id === userID ? { ...p, is_dnp, stats: is_dnp ? null : p.stats } : p,
+            p.member_id === memberID ? { ...p, is_dnp, stats: is_dnp ? null : p.stats } : p,
           ),
         },
       }

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -1,0 +1,94 @@
+import { create } from 'zustand'
+import { gamesApi } from '../api/games'
+import type { Game, GameDetail, GameStats, GamePlayer } from '../types'
+
+interface GameState {
+  games: Game[]
+  currentGame: GameDetail | null
+  isLoading: boolean
+  fetchGames(teamID: string): Promise<void>
+  createGame(teamID: string, data: { opponent_name: string; game_date: string }): Promise<Game>
+  deleteGame(gameID: string): Promise<void>
+  fetchGameDetail(gameID: string): Promise<void>
+  updateGame(
+    gameID: string,
+    data: { opponent_name?: string; game_date?: string; team_score?: number | null; opponent_score?: number | null },
+  ): Promise<void>
+  upsertStats(gameID: string, userID: string, stats: GameStats): Promise<void>
+  toggleDNP(gameID: string, userID: string): Promise<void>
+}
+
+export const useGameStore = create<GameState>((set) => ({
+  games: [],
+  currentGame: null,
+  isLoading: false,
+
+  async fetchGames(teamID: string) {
+    set({ isLoading: true })
+    try {
+      const { games } = await gamesApi.list(teamID)
+      set({ games })
+    } finally {
+      set({ isLoading: false })
+    }
+  },
+
+  async createGame(teamID: string, data: { opponent_name: string; game_date: string }) {
+    const game = await gamesApi.create(teamID, data)
+    set((s) => ({ games: [game, ...s.games] }))
+    return game
+  },
+
+  async deleteGame(gameID: string) {
+    await gamesApi.remove(gameID)
+    set((s) => ({ games: s.games.filter((g) => g.id !== gameID) }))
+  },
+
+  async fetchGameDetail(gameID: string) {
+    set({ isLoading: true, currentGame: null })
+    try {
+      const detail = await gamesApi.getDetail(gameID)
+      set({ currentGame: detail })
+    } finally {
+      set({ isLoading: false })
+    }
+  },
+
+  async updateGame(gameID, data) {
+    const game = await gamesApi.update(gameID, data)
+    set((s) => ({
+      games: s.games.map((g) => (g.id === gameID ? game : g)),
+      currentGame: s.currentGame ? { ...s.currentGame, game } : null,
+    }))
+  },
+
+  async upsertStats(gameID: string, userID: string, stats: GameStats) {
+    const updated = await gamesApi.upsertStats(gameID, userID, stats)
+    set((s) => {
+      if (!s.currentGame) return {}
+      return {
+        currentGame: {
+          ...s.currentGame,
+          players: s.currentGame.players.map((p: GamePlayer) =>
+            p.user_id === userID ? { ...p, stats: updated } : p,
+          ),
+        },
+      }
+    })
+  },
+
+  async toggleDNP(gameID: string, userID: string) {
+    const { is_dnp } = await gamesApi.toggleDNP(gameID, userID)
+    set((s) => {
+      if (!s.currentGame) return {}
+      return {
+        currentGame: {
+          ...s.currentGame,
+          players: s.currentGame.players.map((p: GamePlayer) =>
+            p.user_id === userID ? { ...p, is_dnp, stats: is_dnp ? null : p.stats } : p,
+          ),
+        },
+      }
+    })
+  },
+}))

--- a/frontend/src/stores/teamStore.ts
+++ b/frontend/src/stores/teamStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { teamsApi } from '../api/teams'
-import type { Team, MemberWithUser } from '../types'
+import type { Team, TeamMember, MemberWithUser } from '../types'
 
 interface TeamState {
   teams: Team[]
@@ -14,8 +14,10 @@ interface TeamState {
   createTeam(data: { name: string; sport: string }): Promise<Team>
   updateTeam(teamID: string, data: { name: string }): Promise<Team>
   fetchMembers(teamID: string): Promise<void>
-  inviteMember(teamID: string, email: string): Promise<void>
+  inviteMember(teamID: string, email: string, memberID?: string): Promise<void>
   removeMember(teamID: string, userID: string): Promise<void>
+  addRosterMember(teamID: string, data: { name: string; jersey_number?: number | null; position?: string | null }): Promise<TeamMember>
+  updateMember(teamID: string, memberID: string, data: { jersey_number?: number | null; position?: string | null; name?: string }): Promise<TeamMember>
 }
 
 export const useTeamStore = create<TeamState>((set) => ({
@@ -71,14 +73,29 @@ export const useTeamStore = create<TeamState>((set) => ({
     }
   },
 
-  async inviteMember(teamID: string, email: string) {
-    await teamsApi.inviteMember(teamID, email)
+  async inviteMember(teamID: string, email: string, memberID?: string) {
+    await teamsApi.inviteMember(teamID, email, memberID)
   },
 
   async removeMember(teamID: string, userID: string) {
     await teamsApi.removeMember(teamID, userID)
     set((state) => ({
-      members: state.members.filter((m) => m.user.id !== userID),
+      members: state.members.filter((m) => m.user?.id !== userID),
     }))
+  },
+
+  async addRosterMember(teamID: string, data: { name: string; jersey_number?: number | null; position?: string | null }) {
+    const member = await teamsApi.addRosterMember(teamID, data)
+    const mwu: MemberWithUser = { member, user: null }
+    set((state) => ({ members: [...state.members, mwu] }))
+    return member
+  },
+
+  async updateMember(teamID: string, memberID: string, data: { jersey_number?: number | null; position?: string | null; name?: string }) {
+    const member = await teamsApi.updateMember(teamID, memberID, data)
+    set((state) => ({
+      members: state.members.map((m) => m.member.id === memberID ? { ...m, member } : m),
+    }))
+    return member
   },
 }))

--- a/frontend/src/stores/teamStore.ts
+++ b/frontend/src/stores/teamStore.ts
@@ -77,10 +77,10 @@ export const useTeamStore = create<TeamState>((set) => ({
     await teamsApi.inviteMember(teamID, email, memberID)
   },
 
-  async removeMember(teamID: string, userID: string) {
-    await teamsApi.removeMember(teamID, userID)
+  async removeMember(teamID: string, memberID: string) {
+    await teamsApi.removeMember(teamID, memberID)
     set((state) => ({
-      members: state.members.filter((m) => m.user?.id !== userID),
+      members: state.members.filter((m) => m.member.id !== memberID),
     }))
   },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -81,3 +81,46 @@ export interface Annotation {
   y: number
   text: string
 }
+
+export interface Game {
+  id: string
+  team_id: string
+  opponent_name: string
+  game_date: string  // "YYYY-MM-DD"
+  team_score: number | null
+  opponent_score: number | null
+  created_at: string
+}
+
+export interface GameStats {
+  mins: number
+  pts: number
+  fgm: number
+  fga: number
+  three_pm: number
+  three_pa: number
+  ftm: number
+  fta: number
+  orb: number
+  drb: number
+  ast: number
+  stl: number
+  blk: number
+  tov: number
+  pf: number
+  plus_minus: number
+}
+
+export interface GamePlayer {
+  user_id: string
+  name: string
+  jersey_number: number | null
+  position: string | null
+  is_dnp: boolean
+  stats: GameStats | null
+}
+
+export interface GameDetail {
+  game: Game
+  players: GamePlayer[]
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,7 +18,8 @@ export interface Team {
 export interface TeamMember {
   id: string
   team_id: string
-  user_id: string
+  user_id: string | null   // null for placeholder roster slots
+  name: string | null      // display name for placeholder slots
   role: 'coach' | 'player'
   jersey_number: number | null
   position: string | null
@@ -32,7 +33,7 @@ export interface MemberWithUser {
     name: string
     email: string
     avatar_url: string | null
-  }
+  } | null  // null for placeholder roster slots
 }
 
 export interface Playbook {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -113,7 +113,7 @@ export interface GameStats {
 }
 
 export interface GamePlayer {
-  user_id: string
+  member_id: string
   name: string
   jersey_number: number | null
   position: string | null


### PR DESCRIPTION
## Summary
- Adds `games`, `game_players`, `game_stats` DB tables (migration 000007)
- Full backend CRUD: list/create/get/update/delete games, upsert stats per player, toggle DNP
- Game players auto-seeded from team roster on game creation
- Frontend: `GameDetailPage` with box-score table (editable, computed columns) and live tap-to-increment mode
- Games tab added to `TeamDetailPage`

## Test plan
- [ ] Coach creates a game → all current roster members appear as active players
- [ ] Box score: editing a stat cell and tabbing away saves the stat to the DB
- [ ] Box score: REB, FG%, 3P%, FT% columns compute correctly
- [ ] Box score: DNP button grays out the player; Mark active restores them
- [ ] Live mode: tapping +2PT increments pts/fgm/fga; shows in box score after mode switch
- [ ] Live mode: REB buttons correctly split ORB/DRB
- [ ] Non-coach player can view box score read-only (no input cells, no mode toggle)
- [ ] Game row shows W/L/— based on team vs opponent score

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)